### PR TITLE
fix: add prepare script for GitHub dependency resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "vitest run",
     "test:legacy": "tsx test/abi.test.ts && tsx test/pda.test.ts && tsx test/slab.test.ts && tsx test/validation.test.ts && tsx test/dex-oracle.test.ts",
     "lint": "tsc --noEmit",
+    "prepare": "tsup",
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {


### PR DESCRIPTION
Adds a `prepare` script so that when this package is installed via `github:dcccrypto/percolator-sdk`, tsup runs automatically and `dist/` is available. Required for standalone repos that depend on this package.