### PR TITLE
fix: use tsc for DTS generation to fix CI failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && tsc --emitDeclarationOnly --declaration --outDir dist",
     "test": "vitest run",
     "test:legacy": "tsx test/abi.test.ts && tsx test/pda.test.ts && tsx test/slab.test.ts && tsx test/validation.test.ts && tsx test/dex-oracle.test.ts",
     "lint": "tsc --noEmit",
-    "prepare": "tsup",
+    "prepare": "tsup && tsc --emitDeclarationOnly --declaration --outDir dist",
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,5 +8,8 @@ export default defineConfig({
   clean: true,
   splitting: false,
   sourcemap: true,
-  dts: true,
+  // DTS is generated separately via tsc for reliability in CI
+  // (tsup's rollup-plugin-dts can produce incomplete .d.ts files
+  //  when run inside pnpm's temp prepare directory)
+  dts: false,
 });


### PR DESCRIPTION
## Problem

tsup's `rollup-plugin-dts` produces incomplete `.d.ts` files (252 bytes instead of full ~47KB type bundle) when running inside pnpm's temporary `prepare` directory in CI. This causes TS2305 errors ('has no exported member') in all consuming repos:

- percolator-api
- percolator-keeper  
- percolator-indexer

This is THE blocker for PERC-149 Railway deployment.

## Root Cause

When pnpm installs a GitHub dependency, it clones the repo into a temp directory, runs `pnpm install` there, then runs the `prepare` script. tsup's DTS bundling (via `rollup-plugin-dts`) fails to resolve re-exported types from sub-modules in this temp context, producing only a 252-byte barrel file with empty re-exports instead of the full 47KB bundled declaration file.

## Fix

1. Disable tsup's `dts: true` option (removes `rollup-plugin-dts`)
2. Add `tsc --emitDeclarationOnly --declaration --outDir dist` after tsup in both `build` and `prepare` scripts
3. tsc produces individual `.d.ts` files for each module in the dist/ tree, which TypeScript resolves correctly via the barrel re-exports

## Testing

- Local build produces correct dist/ with all type files
- percolator-api compiles clean with the new DTS structure
- No changes needed in consuming repos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build system reliability by restructuring how TypeScript declaration files are generated, shifting from the bundler to a dedicated compilation step during the build and prepare processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->