### PR TITLE
fix: export ./package.json subpath for Node.js resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Problem
Same issue as percolator-shared#3. Downstream packages that resolve `@percolator/sdk/package.json` fail with `ERR_PACKAGE_PATH_NOT_EXPORTED` in strict Node.js module resolution.

## Fix
Add `"./package.json": "./package.json"` to exports map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct access to package configuration metadata via package exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->