### PR TITLE
fix: fail-closed defaults — program IDs default to mainnet

### DIFF
--- a/src/config/program-ids.ts
+++ b/src/config/program-ids.ts
@@ -35,7 +35,9 @@ export function getProgramId(network?: Network): PublicKey {
   }
 
   // Use provided network or detect from env
-  const targetNetwork = network ?? (process.env.NETWORK as Network) ?? "devnet";
+  // Fail-closed: default to mainnet (not devnet) — matches RULES.md pattern.
+  // Devnet must be explicitly requested via NETWORK=devnet or parameter.
+  const targetNetwork = network ?? (process.env.NETWORK as Network) ?? "mainnet";
   const programId = PROGRAM_IDS[targetNetwork].percolator;
 
   return new PublicKey(programId);
@@ -51,7 +53,8 @@ export function getMatcherProgramId(network?: Network): PublicKey {
   }
 
   // Use provided network or detect from env
-  const targetNetwork = network ?? (process.env.NETWORK as Network) ?? "devnet";
+  // Fail-closed: default to mainnet (not devnet)
+  const targetNetwork = network ?? (process.env.NETWORK as Network) ?? "mainnet";
   const programId = PROGRAM_IDS[targetNetwork].matcher;
 
   if (!programId) {
@@ -63,12 +66,13 @@ export function getMatcherProgramId(network?: Network): PublicKey {
 
 /**
  * Get the current network from environment
- * Defaults to devnet for safety
+ * Defaults to mainnet (fail-closed)
  */
 export function getCurrentNetwork(): Network {
   const network = process.env.NETWORK?.toLowerCase();
-  if (network === "mainnet" || network === "mainnet-beta") {
-    return "mainnet";
+  if (network === "devnet") {
+    return "devnet";
   }
-  return "devnet";
+  // Fail-closed: default to mainnet
+  return "mainnet";
 }


### PR DESCRIPTION
SDK defaulted to devnet for getProgramId(), getMatcherProgramId(), and getCurrentNetwork(). This violates the fail-closed pattern established in PR #753 (percolator-launch).

Now defaults to mainnet. Devnet must be explicitly set via NETWORK=devnet or function parameter.

60/60 tests pass.