### PR TITLE
ci: migrate to Blacksmith runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -26,7 +26,7 @@ jobs:
   publish:
     needs: build-and-test
     if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'release:')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-22.04
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Replaces all runs-on: ubuntu-* with runs-on: blacksmith-2vcpu-ubuntu-22.04 for faster CI. Blacksmith is a drop-in replacement for GitHub Actions runners. No workflow logic changes. Fast-track: trivial infra change, QA + security approve, devops merges.