### PR TITLE
fix(discovery): use layout-descriptor offsets for all V1-family engines

### DIFF
--- a/src/solana/discovery.ts
+++ b/src/solana/discovery.ts
@@ -356,12 +356,12 @@ function parseEngineLight(
     };
   }
 
-  // V_ADL engine struct (PERC-8270/8271): ENGINE_OFF=624, layout-driven offsets.
-  // Must branch here because V_ADL has version===1 same as V1/V1M — differentiate by engineOff.
-  // All offsets from SlabLayout descriptor, which is computed by buildLayoutVADL().
-  const isVAdl = layout !== null && layout.engineOff === 624 && layout.accountSize === 312;
-  if (isVAdl) {
-    const l = layout!;
+  // Layout-descriptor-driven engine parser: handles V_ADL, V_SETDEXPOOL, V12.1, V1M, V1M2,
+  // V1, V1-legacy, and any future layout that populates SlabLayout engine offset fields.
+  // V0 and V2 are already handled above (they return early), so any layout !== null reaching
+  // here has correct descriptor offsets from its buildLayout*() helper.
+  if (layout !== null) {
+    const l = layout;
     return {
       vault: readU128LE(data, base + 0),
       insuranceFund: {


### PR DESCRIPTION
## Summary
- `parseEngineLight` only used layout-descriptor offsets for V_ADL slabs (`engineOff=624 && accountSize=312`)
- V_SETDEXPOOL (`engineOff=648, accountSize=312`) and V12.1 (`engineOff=648, accountSize=320`) fell through to the V1 hardcoded parser, reading **every engine field at the wrong offset** — offsets are 16-568 bytes off depending on the field
- This produces garbage data for vault balances, funding indices, mark prices, open interest, liquidation cursors, and all other engine state on mainnet V12.1 markets
- V1M and V1M2 layouts had the same problem (also fell through to V1 hardcoded parser)
- **Fix**: Broadened the guard condition from `layout.engineOff === 624 && layout.accountSize === 312` to simply `layout !== null`. V0 and V2 already return early before this branch, and all V1-family `buildLayout*()` helpers populate the same `SlabLayout` descriptor fields — making the layout-driven branch forward-compatible with future layout versions

## Test plan
- [x] Full test suite passes (747 passed, 29 skipped)
- [x] Discovery tests pass (60/60)
- [ ] Verify V12.1 slab engine state is parsed correctly (vault, fundingIndex, markPrice, OI)
- [ ] Verify V_SETDEXPOOL slabs parse correctly
- [ ] Verify V_ADL, V1M, V1 slabs still parse correctly (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal engine parsing logic for improved consistency and reliability. Simplified processing flow to use a unified descriptor-based approach across different configuration types, eliminating redundant detection code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->