### PR TITLE
fix(slab): read V12.1 engine funding_index as i64 not i128

### DIFF
--- a/src/solana/slab.ts
+++ b/src/solana/slab.ts
@@ -1941,7 +1941,9 @@ export function parseEngine(data: Uint8Array): EngineState {
         : 0,
     },
     currentSlot: readU64LE(data, base + layout.engineCurrentSlotOff),
-    fundingIndexQpbE6: readI128LE(data, base + layout.engineFundingIndexOff),
+    fundingIndexQpbE6: (layout.engineLastFundingSlotOff - layout.engineFundingIndexOff) === 8
+      ? BigInt(readI64LE(data, base + layout.engineFundingIndexOff))
+      : readI128LE(data, base + layout.engineFundingIndexOff),
     lastFundingSlot: readU64LE(data, base + layout.engineLastFundingSlotOff),
     fundingRateBpsPerSlotLast: readI64LE(data, base + layout.engineFundingRateBpsOff),
     lastCrankSlot: readU64LE(data, base + layout.engineLastCrankSlotOff),


### PR DESCRIPTION
## Summary
- V12.1 changed the engine's `funding_index` field from i128 (16 bytes) to i64 (8 bytes)
- `parseEngine` at line 1944 unconditionally used `readI128LE`, which for V12.1 reads 8 bytes of `funding_index` + 8 bytes of the adjacent `last_funding_slot` — producing a garbage funding index value
- `parseAccount` (line 2098) already had the correct `isV12_1` guard, but `parseEngine` was missed
- **Evidence**: V12.1 offsets `funding_index=936, last_funding_slot=944` (gap=8 bytes), vs all other layouts which have 16-byte gaps (i128)
- **Fix**: Dynamic offset gap detection — `(lastFundingSlotOff - fundingIndexOff) === 8` selects i64 read. Requires zero layout builder changes and auto-adapts to future layouts

## Test plan
- [x] Full test suite passes (747 passed, 29 skipped)
- [x] Gap logic verified correct for V12.1 (8→i64), V_ADL (16→i128), V1D (16→i128), V1 (16→i128)
- [ ] Verify `parseEngine` on a V12.1 slab returns correct `fundingIndexQpbE6` (no bleed into lastFundingSlot)
- [ ] Verify older layout slabs still parse funding_index as i128 correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved engine data parsing to correctly interpret funding index values based on data format specifications, ensuring reliable data handling across different engine configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->