### PR TITLE
fix(abi): make legacy encoders throw on remapped IX tags 22/23/27/28

### DIFF
--- a/src/abi/instructions.ts
+++ b/src/abi/instructions.ts
@@ -639,12 +639,8 @@ export function encodeAdminForceClose(args: AdminForceCloseArgs): Uint8Array {
 }
 
 /**
- * UpdateRiskParams instruction data (17 or 25 bytes)
- * Update initial and maintenance margin BPS (admin only).
- *
- * R2-S13: The Rust program uses `data.len() >= 25` to detect the optional
- * tradingFeeBps field, so variable-length encoding is safe. When tradingFeeBps
- * is omitted, the data is 17 bytes (tag + 2×u64). When included, 25 bytes.
+ * @deprecated Tag 22 is now SetInsuranceWithdrawPolicy on-chain, not UpdateRiskParams.
+ * Use {@link encodeSetInsuranceWithdrawPolicy} instead.
  */
 export interface UpdateRiskParamsArgs {
   initialMarginBps: bigint | string;
@@ -652,16 +648,12 @@ export interface UpdateRiskParamsArgs {
   tradingFeeBps?: bigint | string;
 }
 
-export function encodeUpdateRiskParams(args: UpdateRiskParamsArgs): Uint8Array {
-  const parts = [
-    encU8(IX_TAG.UpdateRiskParams),
-    encU64(args.initialMarginBps),
-    encU64(args.maintenanceMarginBps),
-  ];
-  if (args.tradingFeeBps !== undefined) {
-    parts.push(encU64(args.tradingFeeBps));
-  }
-  return concatBytes(...parts);
+/** @deprecated Tag 22 is now SetInsuranceWithdrawPolicy. Use encodeSetInsuranceWithdrawPolicy(). */
+export function encodeUpdateRiskParams(_args: UpdateRiskParamsArgs): Uint8Array {
+  throw new Error(
+    "encodeUpdateRiskParams is removed: IX tag 22 is now SetInsuranceWithdrawPolicy on-chain. " +
+    "Use encodeSetInsuranceWithdrawPolicy() instead.",
+  );
 }
 
 /**
@@ -676,16 +668,16 @@ export const RENOUNCE_ADMIN_CONFIRMATION = 0x52454E4F554E4345n;
 export const UNRESOLVE_CONFIRMATION = 0xDEAD_BEEF_CAFE_1234n;
 
 /**
- * RenounceAdmin instruction data (9 bytes)
- * Irreversibly set admin to all zeros. After this, all admin-only instructions fail.
- *
- * Requires the confirmation code 0x52454E4F554E4345 ("RENOUNCE" as u64 LE)
- * to prevent accidental invocation.
+ * @deprecated Tag 23 is now WithdrawInsuranceLimited on-chain, not RenounceAdmin.
+ * Use {@link encodeWithdrawInsuranceLimited} instead.
+ * CRITICAL: The old implementation sent the RENOUNCE confirmation code (0x52454E4F554E4345)
+ * as a u64 on tag 23, which would be interpreted as a ~5.93e18 token withdrawal amount.
  */
 export function encodeRenounceAdmin(): Uint8Array {
-  return concatBytes(
-    encU8(IX_TAG.RenounceAdmin),
-    encU64(RENOUNCE_ADMIN_CONFIRMATION),
+  throw new Error(
+    "encodeRenounceAdmin is removed: IX tag 23 is now WithdrawInsuranceLimited on-chain. " +
+    "The old implementation would attempt to withdraw ~5.93e18 tokens from insurance. " +
+    "Use encodeWithdrawInsuranceLimited() instead.",
   );
 }
 
@@ -743,19 +735,23 @@ export function encodeLpVaultWithdraw(args: LpVaultWithdrawArgs): Uint8Array {
 }
 
 /**
- * PauseMarket instruction data (1 byte)
- * Pauses the market — disables trading, deposits, and withdrawals.
+ * @deprecated Tag 27 is now DepositFeeCredits on-chain. There is no PauseMarket instruction.
  */
 export function encodePauseMarket(): Uint8Array {
-  return encU8(IX_TAG.PauseMarket);
+  throw new Error(
+    "encodePauseMarket is removed: IX tag 27 is now DepositFeeCredits on-chain. " +
+    "There is no PauseMarket instruction.",
+  );
 }
 
 /**
- * UnpauseMarket instruction data (1 byte)
- * Unpauses the market — re-enables trading, deposits, and withdrawals.
+ * @deprecated Tag 28 is now ConvertReleasedPnl on-chain. There is no UnpauseMarket instruction.
  */
 export function encodeUnpauseMarket(): Uint8Array {
-  return encU8(IX_TAG.UnpauseMarket);
+  throw new Error(
+    "encodeUnpauseMarket is removed: IX tag 28 is now ConvertReleasedPnl on-chain. " +
+    "There is no UnpauseMarket instruction.",
+  );
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Four legacy encoder functions used deprecated IX_TAG aliases that map to **completely different on-chain instructions** after tag remapping:

| Function | Tag | Actually calls on-chain | Risk |
|----------|-----|------------------------|------|
| `encodeUpdateRiskParams` | 22 | `SetInsuranceWithdrawPolicy` | Data layout mismatch → rejected |
| `encodeRenounceAdmin` | 23 | `WithdrawInsuranceLimited` | **CRITICAL**: sends RENOUNCE code (~5.93e18) as withdrawal amount — could drain insurance |
| `encodePauseMarket` | 27 | `DepositFeeCredits` | No payload → rejected |
| `encodeUnpauseMarket` | 28 | `ConvertReleasedPnl` | No payload → rejected |

- `encodeRenounceAdmin` is the most dangerous: its 9-byte layout (tag + u64) **exactly matches** `WithdrawInsuranceLimited`, so the program would interpret the RENOUNCE confirmation code as a withdrawal of ~5.93 quintillion tokens
- All four functions now throw descriptive `Error` messages pointing to correct replacements
- Functions preserved as exports with `@deprecated` JSDoc — no compile-time breakage for existing consumers
- Correct encoders (`encodeSetInsuranceWithdrawPolicy`, `encodeWithdrawInsuranceLimited`) already exist in the codebase

## Test plan
- [x] Full test suite passes (747 passed, 29 skipped) — no existing tests called these functions
- [ ] Verify `encodeUpdateRiskParams()` throws with message mentioning `encodeSetInsuranceWithdrawPolicy`
- [ ] Verify `encodeRenounceAdmin()` throws with message about insurance fund risk
- [ ] Verify `encodePauseMarket()` and `encodeUnpauseMarket()` throw with clear explanations

🤖 Generated with [Claude Code](https://claude.com/claude-code)