### PR TITLE
fix(math): use pure BigInt arithmetic in warmup to avoid BigInt(float) crash

### DIFF
--- a/src/math/warmup.ts
+++ b/src/math/warmup.ts
@@ -90,7 +90,8 @@ export function computeWarmupLeverageCap(
   if (unlocked <= 0n) return 1; // At least 1x if nothing unlocked yet (slot 0 edge)
 
   // Effective leverage = maxLev * (unlocked / total), floored, min 1
-  const scaledResult = (BigInt(maxLev) * unlocked) / totalCapital;
+  // Pure BigInt arithmetic avoids BigInt(float) crash when maxLev is fractional
+  const scaledResult = (10000n * unlocked) / (initialMarginBps * totalCapital);
 
   // Ensure conversion to Number doesn't silently truncate for very large values
   if (scaledResult > BigInt(Number.MAX_SAFE_INTEGER)) {
@@ -126,14 +127,15 @@ export function computeWarmupMaxPositionSize(
   warmupStartSlot: bigint,
   warmupPeriodSlots: bigint,
 ): bigint {
-  const maxLev = computeMaxLeverage(initialMarginBps);
   const unlocked = computeWarmupUnlockedCapital(
     totalCapital,
     currentSlot,
     warmupStartSlot,
     warmupPeriodSlots,
   );
-  return unlocked * BigInt(maxLev);
+  // Pure BigInt arithmetic: (unlocked * 10000) / initialMarginBps
+  // Avoids BigInt(float) crash when computeMaxLeverage returns non-integer
+  return (unlocked * 10000n) / initialMarginBps;
 }
 
 /**


### PR DESCRIPTION
## Summary
- `computeWarmupLeverageCap` (line 93) and `computeWarmupMaxPositionSize` (line 136) called `BigInt()` on the return value of `computeMaxLeverage()`, which returns a **float** (e.g., `3.003` for 3333 bps)
- `BigInt(3.003)` throws `TypeError: Cannot convert a non-integer to a BigInt`
- This crashes for any `initialMarginBps` that doesn't evenly divide 10000 — common values like 3333 (~3x), 300 (~33x), 700 (~14x), 1500 (~6.7x)
- Existing tests only used exact divisors (1000, 500, 200, 10000) which masked the bug
- **Fix**: Pure BigInt arithmetic — `(unlocked * 10000n) / initialMarginBps` — algebraically equivalent, no float conversion, preserves full precision

## Test plan
- [x] Full test suite passes (747 passed, 29 skipped)
- [x] Verified: `initialMarginBps=3333n` now produces correct position size (1500150) instead of crashing
- [x] Verified: `initialMarginBps=1000n` still produces correct result (5000000)
- [ ] Verify `computeWarmupLeverageCap` with non-divisor margin values doesn't crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)