### PR TITLE
fix(stake): env var must not supersede explicit network param

### DIFF
--- a/src/solana/stake.ts
+++ b/src/solana/stake.ts
@@ -31,12 +31,17 @@ export const STAKE_PROGRAM_IDS = {
  * surface the gap instead of silently hitting the devnet program.
  */
 export function getStakeProgramId(network?: 'devnet' | 'mainnet'): PublicKey {
-  const override = safeEnv('STAKE_PROGRAM_ID');
-  if (override) {
-    console.warn(
-      `[percolator-sdk] STAKE_PROGRAM_ID env override active: ${override} — ensure this points to a trusted program`,
-    );
-    return new PublicKey(override);
+  // Only allow env override when no explicit network is provided —
+  // an explicit parameter should always take precedence to prevent
+  // silent program substitution via environment variable injection.
+  if (!network) {
+    const override = safeEnv('STAKE_PROGRAM_ID');
+    if (override) {
+      console.warn(
+        `[percolator-sdk] STAKE_PROGRAM_ID env override active: ${override} — ensure this points to a trusted program`,
+      );
+      return new PublicKey(override);
+    }
   }
 
   const detectedNetwork =


### PR DESCRIPTION
## Summary
- `getStakeProgramId()` checked `STAKE_PROGRAM_ID` env var **before** the explicit `network` parameter — same pattern fixed for `getProgramId` in PR #142
- An attacker who sets the env var could redirect staking transactions to a malicious program even when the caller explicitly passes `'mainnet'`
- Now only applies env override when no explicit `network` is provided — consistent with `getProgramId` behavior

## Test plan
- [x] Stake tests pass (58/58)
- [ ] Verify `getStakeProgramId('mainnet')` returns hardcoded mainnet ID even when `STAKE_PROGRAM_ID` env is set
- [ ] Verify `getStakeProgramId()` (no arg) still respects env override for backward compat

🤖 Generated with [Claude Code](https://claude.com/claude-code)