### PR TITLE
fix(adl): isAdlTriggered must throw on unrecognized layout

### DIFF
--- a/src/solana/adl.ts
+++ b/src/solana/adl.ts
@@ -144,17 +144,16 @@ function computePnlPct(pnl: bigint, capital: bigint): bigint {
 export function isAdlTriggered(slabData: Uint8Array): boolean {
   const layout = detectSlabLayout(slabData.length);
   if (!layout) {
-    return false;
+    throw new Error(
+      `isAdlTriggered: unrecognized slab layout (${slabData.length} bytes). ` +
+      `Cannot determine ADL status — update the SDK or check the data source.`,
+    );
   }
-  try {
-    const engine = parseEngine(slabData);
-    if (engine.pnlPosTot === 0n) return false;
-    const config = parseConfig(slabData, layout);
-    if (config.maxPnlCap === 0n) return false;
-    return engine.pnlPosTot > config.maxPnlCap;
-  } catch {
-    return false;
-  }
+  const engine = parseEngine(slabData);
+  if (engine.pnlPosTot === 0n) return false;
+  const config = parseConfig(slabData, layout);
+  if (config.maxPnlCap === 0n) return false;
+  return engine.pnlPosTot > config.maxPnlCap;
 }
 
 /**

--- a/test/adl.test.ts
+++ b/test/adl.test.ts
@@ -156,16 +156,16 @@ describe("rankAdlPositions — unit tests on pure ranking logic", () => {
 // ---------------------------------------------------------------------------
 
 describe("isAdlTriggered", () => {
-  it("returns false for invalid/empty slab data", () => {
-    // Empty data — detectSlabLayout returns null → false
+  it("throws for invalid/empty slab data", () => {
+    // Empty data — detectSlabLayout returns null → must throw, not silently return false
     const emptyData = new Uint8Array(0);
-    expect(isAdlTriggered(emptyData)).toBe(false);
+    expect(() => isAdlTriggered(emptyData)).toThrow("unrecognized slab layout");
   });
 
-  it("returns false for unrecognized data length", () => {
-    // Random size not matching any known slab layout
+  it("throws for unrecognized data length", () => {
+    // Random size not matching any known slab layout — must surface the error
     const garbage = new Uint8Array(100).fill(0xff);
-    expect(isAdlTriggered(garbage)).toBe(false);
+    expect(() => isAdlTriggered(garbage)).toThrow("unrecognized slab layout");
   });
 });
 


### PR DESCRIPTION
## Summary
- `isAdlTriggered` silently returned `false` when the slab layout was unrecognized or engine/config parsing failed
- A keeper monitoring ADL status would believe no ADL was needed when it couldn't read the slab — hiding protocol risk during PnL cap breaches
- If a program upgrade changes slab layout and the SDK hasn't been updated, ADL monitoring silently stops working
- Now throws with a descriptive error for unrecognized layouts; parse errors propagate naturally

## Test plan
- [x] Full test suite passes (747 passed, 29 skipped)
- [x] Updated tests: invalid/empty data and unrecognized lengths now expect throws
- [ ] Verify valid slab data still returns correct ADL trigger status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to throw exceptions with descriptive messages when data validation fails, replacing silent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->