### PR TITLE
fix(adl): remove Buffer.from for browser compatibility

### DIFF
--- a/src/solana/adl.ts
+++ b/src/solana/adl.ts
@@ -324,7 +324,7 @@ export function buildAdlInstruction(
     );
   }
   const dataBytes = encodeExecuteAdl({ targetIdx });
-  const data = Buffer.from(dataBytes);
+  const data = dataBytes as Buffer; // Uint8Array is accepted by TransactionInstruction
 
   const keys: AccountMeta[] = [
     { pubkey: caller, isSigner: true, isWritable: false },


### PR DESCRIPTION
## Summary
- `buildAdlInstruction` wrapped `encodeExecuteAdl()` output in `Buffer.from()` which crashes in browsers with `ReferenceError: Buffer is not defined`
- The `Uint8Array` returned by `encodeExecuteAdl` is already accepted by `TransactionInstruction` at runtime
- This was the last remaining `Buffer.from` usage in executable source code

## Test plan
- [x] Full test suite passes (747 passed, 29 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)