### PR TITLE
fix(slab): use V1_LEGACY_ACCT_OWNER_OFF for legacy slab accounts

### DIFF
--- a/src/solana/slab.ts
+++ b/src/solana/slab.ts
@@ -734,7 +734,7 @@ function buildLayout(version: 0 | 1, maxAccounts: number, engineOffOverride?: nu
     engineLastBreakerSlotOff: isV0 ? -1 : V1_ENGINE_LAST_BREAKER_SLOT_OFF,
     engineBitmapOff: actualBitmapOff,
     postBitmap: 18,
-    acctOwnerOff: ACCT_OWNER_OFF,
+    acctOwnerOff: isV1Legacy ? V1_LEGACY_ACCT_OWNER_OFF : ACCT_OWNER_OFF,
 
     hasInsuranceIsolation: !isV0,
     engineInsuranceIsolatedOff: isV0 ? -1 : 48,


### PR DESCRIPTION
## Summary
- `V1_LEGACY_ACCT_OWNER_OFF=200` was defined but never used in `buildLayout` — all layouts used `ACCT_OWNER_OFF=184`
- On V1-legacy slabs (orphaned devnet slabs with ENGINE_OFF=640), the owner pubkey is at offset 200 not 184
- This caused `parseAccount` to read the wrong 32 bytes as the owner address for legacy account slots

## Test plan
- [x] Full test suite passes (747 passed, 29 skipped)
- [ ] Verify V1-legacy slab accounts return correct owner pubkeys

🤖 Generated with [Claude Code](https://claude.com/claude-code)