### PR TITLE
fix(discovery): add V_SETDEXPOOL and V1M2 tiers to ALL_TIERS

### DIFF
--- a/src/solana/discovery.ts
+++ b/src/solana/discovery.ts
@@ -7,6 +7,8 @@ import {
   SLAB_TIERS_V1M,
   SLAB_TIERS_V2,
   SLAB_TIERS_V_ADL,
+  SLAB_TIERS_V_SETDEXPOOL,
+  SLAB_TIERS_V1M2,
   SLAB_TIERS_V12_1,
   type SlabHeader,
   type MarketConfig,
@@ -592,6 +594,8 @@ export async function discoverMarkets(
     ...Object.values(SLAB_TIERS_V2),
     ...Object.values(SLAB_TIERS_V1M),
     ...Object.values(SLAB_TIERS_V_ADL),
+    ...Object.values(SLAB_TIERS_V_SETDEXPOOL),
+    ...Object.values(SLAB_TIERS_V1M2),
   ];
   type RawEntry = { pubkey: PublicKey; account: { data: Buffer | Uint8Array }; maxAccounts: number; dataSize: number };
   let rawAccounts: RawEntry[] = [];

--- a/test/discovery.test.ts
+++ b/test/discovery.test.ts
@@ -13,6 +13,8 @@ import {
   SLAB_TIERS_V2,
   SLAB_TIERS_V1M,
   SLAB_TIERS_V_ADL,
+  SLAB_TIERS_V_SETDEXPOOL,
+  SLAB_TIERS_V1M2,
 } from "../src/solana/slab.js";
 
 // ============================================================================
@@ -439,7 +441,9 @@ describe("discoverMarkets — sequential mode (PERC-1650)", () => {
       Object.keys(SLAB_TIERS_V1D_LEGACY).length +
       Object.keys(SLAB_TIERS_V2).length +
       Object.keys(SLAB_TIERS_V1M).length +
-      Object.keys(SLAB_TIERS_V_ADL).length;
+      Object.keys(SLAB_TIERS_V_ADL).length +
+      Object.keys(SLAB_TIERS_V_SETDEXPOOL).length +
+      Object.keys(SLAB_TIERS_V1M2).length;
     expect(callCount).toBeLessThanOrEqual(allTierCount + 2); // +2 for rounding
     // Memcmp fallback was called (0 raw accounts → fallback triggered)
     expect(memcmpCallCount).toBe(1);


### PR DESCRIPTION
## Summary
- `ALL_TIERS` in `discoverMarkets` was missing `SLAB_TIERS_V_SETDEXPOOL` and `SLAB_TIERS_V1M2`
- On-chain slabs matching these tier sizes would be undiscoverable by the primary `getProgramAccounts` dataSize filter, falling through to the less reliable memcmp fallback or being missed entirely
- Same class of bug documented in GH#1237/GH#1238 for V1D_LEGACY tiers
- Updated test tier count to include the new tiers

## Test plan
- [x] Full test suite passes (747 passed, 29 skipped)
- [ ] Verify V_SETDEXPOOL and V1M2 slabs are discovered via dataSize filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)