### PR TITLE
fix(abi): export ErrorInfo interface for consumer type annotations

### DIFF
--- a/src/abi/errors.ts
+++ b/src/abi/errors.ts
@@ -2,7 +2,7 @@
  * Percolator program error definitions.
  * Each error includes a name and actionable guidance.
  */
-interface ErrorInfo {
+export interface ErrorInfo {
   name: string;
   hint: string;
 }


### PR DESCRIPTION
## Summary
- `ErrorInfo` interface in `errors.ts` was declared without `export`
- `decodeError()` returns `ErrorInfo | undefined` but consumers couldn't name or import the type
- Breaks type-safe error handling patterns (type guards, annotations, generic constraints)
- Added `export` keyword — one-character fix

## Test plan
- [x] Full test suite passes (747 passed, 29 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **API Changes**
  * Made internal error information interface publicly available for external integration and development purposes.

---

**Note:** This is a technical API enhancement with minimal direct impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->