### PR TITLE
fix(docs): correct ExecuteAdl permission to admin-required

### DIFF
--- a/src/abi/instructions.ts
+++ b/src/abi/instructions.ts
@@ -996,9 +996,9 @@ export function encodeCancelQueuedWithdrawal(): Uint8Array {
 /**
  * ExecuteAdl (Tag 50, PERC-305) — auto-deleverage the most profitable position.
  *
- * Permissionless. Surgically closes or reduces `targetIdx` position when
- * `pnl_pos_tot > max_pnl_cap` on the market. The caller receives no reward —
- * the incentive is unblocking the market for normal trading.
+ * Requires the caller to be the market admin/keeper authority (`header.admin`).
+ * Surgically closes or reduces `targetIdx` position when
+ * `pnl_pos_tot > max_pnl_cap` on the market.
  *
  * Requires `UpdateRiskParams.max_pnl_cap > 0` on the market.
  *


### PR DESCRIPTION
## Summary
- `instructions.ts` line 999 said ExecuteAdl was "Permissionless"
- `adl.ts` lines 9-11 and `buildAdlInstruction` docs (line 289-291) both say it requires the market admin/keeper authority (`header.admin`)
- This contradiction could mislead integrators — building bots that fail on every ADL attempt, or misunderstanding access requirements
- Aligned `instructions.ts` with the authoritative `adl.ts` documentation

## Test plan
- [x] Full test suite passes (747 passed, 29 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)