### PR TITLE
fix(rpc-pool): use digit-boundary regex in isRetryable to prevent false positives

### DIFF
--- a/src/solana/rpc-pool.ts
+++ b/src/solana/rpc-pool.ts
@@ -281,19 +281,25 @@ function endpointLabel(ep: RpcEndpointConfig): string {
 function isRetryable(err: unknown, codes: number[]): boolean {
   if (!err) return false;
   const msg = err instanceof Error ? err.message : String(err);
+  // Match HTTP status codes only when NOT embedded inside a larger number.
+  // Prevents false positives like "Account has 50429 lamports" matching "429".
   for (const code of codes) {
-    if (msg.includes(String(code))) return true;
+    const pattern = new RegExp(`(?<![0-9])${code}(?![0-9])`);
+    if (pattern.test(msg)) return true;
   }
-  // Generic network errors
+  // Generic network / transient error keywords
+  const lower = msg.toLowerCase();
   if (
-    msg.toLowerCase().includes("rate limit") ||
-    msg.toLowerCase().includes("too many requests") ||
-    msg.toLowerCase().includes("econnreset") ||
-    msg.toLowerCase().includes("econnrefused") ||
-    msg.toLowerCase().includes("socket hang up") ||
-    msg.toLowerCase().includes("network") ||
-    msg.toLowerCase().includes("timeout") ||
-    msg.toLowerCase().includes("abort")
+    lower.includes("rate limit") ||
+    lower.includes("too many requests") ||
+    lower.includes("bad gateway") ||
+    lower.includes("service unavailable") ||
+    lower.includes("econnreset") ||
+    lower.includes("econnrefused") ||
+    lower.includes("socket hang up") ||
+    lower.includes("network") ||
+    lower.includes("timeout") ||
+    lower.includes("abort")
   ) {
     return true;
   }


### PR DESCRIPTION
## Summary
- `isRetryable` used `msg.includes(String(code))` to match HTTP status codes like 429/502/503/504
- This caused **false-positive retries** when error messages contained those digits as substrings of larger numbers:
  - `"Account has 50429 lamports"` matched `"429"` → retried an insufficient-funds error
  - `"Airdrop of 150200 lamports"` matched `"502"` → retried a non-retryable error
  - Any slot number, account balance, or tx signature containing these digit sequences triggered false matches
- On mainnet, this wastes ~15 seconds retrying errors that will never succeed, masking the real error from callers
- **Fix**: Negative lookaround regex `(?<![0-9])CODE(?![0-9])` ensures codes only match when NOT embedded in larger numbers
- Added `"bad gateway"` and `"service unavailable"` keywords for defense-in-depth 502/503 coverage
- Cached `msg.toLowerCase()` to avoid 8+ redundant calls per error check

## Test plan
- [x] All 57 rpc-pool tests pass
- [x] Full test suite passes (747 passed, 29 skipped)
- [x] Verified: `"50429 lamports"` no longer matches `429` (false positive eliminated)
- [x] Verified: `"HTTP 429 Too Many Requests"` still matches (true positive preserved)
- [x] Verified: `"502 Bad Gateway"`, `"status: 503"`, `"Gateway Timeout 504"` all still match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana RPC connection retry logic to more accurately detect transient network errors and service unavailability, reducing false retries and enhancing the reliability of RPC operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->