### PR TITLE
fix(adl): pass slab data to detectSlabLayout for V2 disambiguation

### DIFF
--- a/src/solana/adl.ts
+++ b/src/solana/adl.ts
@@ -142,7 +142,7 @@ function computePnlPct(pnl: bigint, capital: bigint): bigint {
  * ```
  */
 export function isAdlTriggered(slabData: Uint8Array): boolean {
-  const layout = detectSlabLayout(slabData.length);
+  const layout = detectSlabLayout(slabData.length, slabData);
   if (!layout) {
     return false;
   }
@@ -193,7 +193,7 @@ export async function fetchAdlRankedPositions(
  * Useful when you already have the slab data (e.g., from a subscription).
  */
 export function rankAdlPositions(slabData: Uint8Array): AdlRankingResult {
-  const layout = detectSlabLayout(slabData.length);
+  const layout = detectSlabLayout(slabData.length, slabData);
 
   let pnlPosTot = 0n;
   try {


### PR DESCRIPTION
## Summary
- `isAdlTriggered` (line 145) and `rankAdlPositions` (line 196) called `detectSlabLayout(slabData.length)` without passing the data buffer
- V2 slabs have identical sizes to V1D — disambiguation requires reading the version field at offset 8, which needs the data buffer
- Without it, V2 slabs are misdetected as V1D (ENGINE_OFF 424 vs 600 = 176-byte offset difference)
- `parseConfig` then reads config fields from completely wrong offsets, producing garbage `maxPnlCap` — causing missed or false ADL triggers
- **Fix**: Pass `slabData` as the second argument at both call sites

## Test plan
- [x] ADL tests pass (26/26)
- [x] Full test suite passes (747 passed, 29 skipped)
- [ ] Verify V2 slab data produces correct ADL trigger assessment
- [ ] Verify V1D slab data still works correctly (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved position detection and ranking accuracy by enhancing data processing in Auto Deleveraging calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->