### PR TITLE
fix(math): computeWarmupProgress maturedPnl must respect reservedPnl

### DIFF
--- a/src/math/warmup.ts
+++ b/src/math/warmup.ts
@@ -221,14 +221,14 @@ export function computeWarmupProgress(
   const progressBps = (elapsed * 10000n) / warmupPeriodSlots;
   const slotsRemaining = warmupPeriodSlots - elapsed;
 
-  // Matured PnL = total PnL × progress%, capped at total PnL
-  // This represents the portion of PnL that has been linearly released
-  const maturedPnl = pnl > 0n
-    ? ((pnl * progressBps) / 10000n)
-    : 0n;
+  // Matured PnL = pnl minus the on-chain reserved amount.
+  // The time-based linear release (pnl * progress%) is the theoretical cap,
+  // but the actual available amount is determined by what's still reserved.
+  const timeReleased = pnl > 0n ? ((pnl * progressBps) / 10000n) : 0n;
+  const fromReserved = pnl > 0n && pnl > reservedPnl ? pnl - reservedPnl : 0n;
+  // Use the lesser of time-released and unreserved to avoid overstating
+  const maturedPnl = timeReleased < fromReserved ? timeReleased : fromReserved;
 
-  // The actual reserved amount from the account remains reserved, but
-  // we can also compute how much is still locked by comparing to matured
   const locked = reservedPnl > 0n ? reservedPnl : 0n;
 
   return {


### PR DESCRIPTION
## Summary
- `computeWarmupProgress` computed `maturedPnl` purely from time-based progress (`pnl * progressBps / 10000`), ignoring the on-chain `reservedPnl` parameter
- This could report `matured + reserved > total pnl` — e.g., with 50% progress, pnl=1 SOL, reservedPnl=0.6 SOL: old code returned maturedPnl=0.5 SOL (matured+reserved=1.1 SOL > 1.0 SOL pnl)
- Contradicted the docstring example which shows `maturedPnl: 400000000n` (0.4 SOL = pnl - reservedPnl)
- **Fix**: Takes the minimum of time-released amount and unreserved amount, ensuring `matured + reserved <= total pnl`

## Test plan
- [x] Full test suite passes (747 passed, 29 skipped)
- [x] Verified docstring example: maturedPnl=400M, matured+reserved=1B <= pnl=1B

🤖 Generated with [Claude Code](https://claude.com/claude-code)