### PR TITLE
fix(slab): document resolvedSlot as unpopulated stub in MarketConfig

### DIFF
--- a/src/solana/slab.ts
+++ b/src/solana/slab.ts
@@ -1435,6 +1435,11 @@ export interface MarketConfig {
   adaptiveMaxFundingBps: bigint;
   marketCreatedSlot: bigint;
   oiRampSlots: bigint;
+  /**
+   * Slot at which the market was resolved. Currently always `0n` — the on-chain
+   * resolved state is tracked via the header's FLAG_RESOLVED bit, not the config.
+   * This field is reserved for future use; do not rely on it for resolution checks.
+   */
   resolvedSlot: bigint;
   insuranceIsolationBps: number;
   /** PERC-622: Oracle phase (0=Nascent, 1=Growing, 2=Mature) */


### PR DESCRIPTION
## Summary
- `MarketConfig.resolvedSlot` was declared as `bigint` and always returned `0n` — no code path ever reads this from on-chain data
- Consumers relying on this field for resolution checks would silently get `0n` regardless of actual market state
- The on-chain resolved state is tracked via the header's `FLAG_RESOLVED` bit, not the config struct
- Added JSDoc documenting this as a reserved stub field, directing consumers to use the header flag

## Test plan
- [x] Full test suite passes (747 passed, 29 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)