### PR TITLE
fix(slab): expose V12_1 position_basis_q as dedicated Account field

### DIFF
--- a/src/solana/adl.ts
+++ b/src/solana/adl.ts
@@ -49,7 +49,7 @@ import { encodeExecuteAdl } from "../abi/instructions.js";
 // Types
 // ---------------------------------------------------------------------------
 
-/** Position side derived from positionSize sign. */
+/** Position side derived from the signed position field's sign. */
 export type AdlSide = "long" | "short";
 
 /**
@@ -62,8 +62,16 @@ export interface AdlRankedPosition {
   idx: number;
   /** Owner public key. */
   owner: PublicKey;
-  /** Raw position size (i128 — negative = short, positive = long). */
-  positionSize: bigint;
+  /**
+   * Signed position indicator (i128 — negative = short, positive = long).
+   *
+   * - For pre-V12_1 accounts this is `position_size` (lots).
+   * - For V12_1+ accounts this is `position_basis_q` (signed quote basis).
+   *
+   * Only the sign is meaningful for ADL ranking; the magnitude differs between
+   * the two layouts and should not be cross-compared.
+   */
+  positionSigned: bigint;
   /** Realised + mark-to-market PnL in lamports (i128 from slab). */
   pnl: bigint;
   /** Capital at entry in lamports (u128). */
@@ -225,23 +233,18 @@ export function rankAdlPositions(slabData: Uint8Array): AdlRankingResult {
   const positions: AdlRankedPosition[] = [];
   for (const { idx, account } of accounts) {
     if (account.kind !== AccountKind.User) continue;
-    if (account.positionSize === 0n) continue;
+
+    // Pick the signed position indicator from whichever layout this account
+    // came from: V12_1+ accounts populate positionBasisQ, older layouts
+    // populate positionSize. The sign (long/short) is consistent across both.
+    const positionSigned: bigint =
+      account.positionBasisQ !== 0n ? account.positionBasisQ : account.positionSize;
+    if (positionSigned === 0n) continue;
 
     // Determine side from sign convention: long (> 0), short (< 0).
-    // If positionSize is 0, it was already skipped above.
-    const side: AdlSide = account.positionSize > 0n ? "long" : "short";
+    const side: AdlSide = positionSigned > 0n ? "long" : "short";
 
-    // Validate sign convention: longs must be positive, shorts must be negative.
-    if (side === "long" && account.positionSize <= 0n) {
-      console.warn(`[fetchAdlRankedPositions] account idx=${idx}: side=long but positionSize=${account.positionSize}`);
-      continue;
-    }
-    if (side === "short" && account.positionSize >= 0n) {
-      console.warn(`[fetchAdlRankedPositions] account idx=${idx}: side=short but positionSize=${account.positionSize}`);
-      continue;
-    }
-
-    // For shorts, positionSize is negative — PnL computation is symmetric:
+    // For shorts, positionSigned is negative — PnL computation is symmetric:
     // a short profits when price falls, so pnl stored in the slab already
     // reflects mark-to-market gain/loss for both sides.
     const pnlPct = computePnlPct(account.pnl, account.capital);
@@ -249,7 +252,7 @@ export function rankAdlPositions(slabData: Uint8Array): AdlRankingResult {
     positions.push({
       idx,
       owner: account.owner,
-      positionSize: account.positionSize,
+      positionSigned,
       pnl: account.pnl,
       capital: account.capital,
       pnlPct,

--- a/src/solana/slab.ts
+++ b/src/solana/slab.ts
@@ -454,7 +454,9 @@ const V12_1_ACCT_LAST_FEE_SLOT_OFF = 256;   // was 240 in V_ADL
 // SBF offsets (empirically verified via repr(C) with u128 align=8):
 // position_basis_q is at offset 88 on SBF (between warmup_slope_per_step and adl_a_basis)
 // entry_price was REMOVED from Account in V12_1 upstream rebase
-const V12_1_ACCT_POSITION_SIZE_OFF = 88;     // position_basis_q: i128 at offset 88 (SBF)
+// In V12_1, both position_size and entry_price were collapsed into the single
+// position_basis_q (i128) field, which encodes the signed quote-denominated basis.
+const V12_1_ACCT_POSITION_BASIS_Q_OFF = 88;  // position_basis_q: i128 at offset 88 (SBF)
 const V12_1_ACCT_ENTRY_PRICE_OFF = -1;       // REMOVED in V12_1 — does not exist
 const V12_1_ACCT_FUNDING_INDEX_OFF = 288;    // moved to end (legacy, i64 not i128)
 
@@ -1549,7 +1551,23 @@ export interface Account {
   reservedPnl: bigint;
   warmupStartedAtSlot: bigint;
   warmupSlopePerStep: bigint;
+  /**
+   * Pre-V12_1 ONLY: signed position size in lots (i128).
+   * `0n` on V12_1+ accounts because the protocol replaced `position_size`
+   * with `positionBasisQ`. Use `positionBasisQ` for V12_1+ accounts.
+   */
   positionSize: bigint;
+  /**
+   * V12_1+ ONLY: signed position quote basis (i128, `position_basis_q` on chain).
+   * Sign indicates side (positive = long, negative = short). This field replaced
+   * `position_size` and `entry_price` in the V12_1 protocol upgrade.
+   * `0n` on pre-V12_1 accounts.
+   */
+  positionBasisQ: bigint;
+  /**
+   * Pre-V12_1 ONLY: entry price (u64). `0n` on V12_1+ where `entry_price` was
+   * removed and folded into `positionBasisQ`.
+   */
   entryPrice: bigint;
   fundingIndex: bigint;
   matcherProgram: PublicKey;
@@ -2093,7 +2111,10 @@ export function parseAccount(data: Uint8Array, idx: number): Account {
   const isAdl = layout.accountSize >= 312 || isV12_1;
   const warmupStartedOff = isAdl ? V_ADL_ACCT_WARMUP_STARTED_OFF : ACCT_WARMUP_STARTED_OFF;
   const warmupSlopeOff   = isAdl ? V_ADL_ACCT_WARMUP_SLOPE_OFF   : ACCT_WARMUP_SLOPE_OFF;
-  const positionSizeOff  = isV12_1 ? V12_1_ACCT_POSITION_SIZE_OFF : (isAdl ? V_ADL_ACCT_POSITION_SIZE_OFF : ACCT_POSITION_SIZE_OFF);
+  // For V12_1, this offset points at position_basis_q (NOT position_size — see
+  // V12_1_ACCT_POSITION_BASIS_Q_OFF). The value is read into the dedicated
+  // positionBasisQ field below; positionSize is set to 0n for V12_1.
+  const positionFieldOff = isV12_1 ? V12_1_ACCT_POSITION_BASIS_Q_OFF : (isAdl ? V_ADL_ACCT_POSITION_SIZE_OFF : ACCT_POSITION_SIZE_OFF);
   const entryPriceOff    = isV12_1 ? V12_1_ACCT_ENTRY_PRICE_OFF   : (isAdl ? V_ADL_ACCT_ENTRY_PRICE_OFF   : ACCT_ENTRY_PRICE_OFF);
   const fundingIndexOff  = isV12_1 ? V12_1_ACCT_FUNDING_INDEX_OFF : (isAdl ? V_ADL_ACCT_FUNDING_INDEX_OFF : ACCT_FUNDING_INDEX_OFF);
   const matcherProgOff   = isV12_1 ? V12_1_ACCT_MATCHER_PROGRAM_OFF : (isAdl ? V_ADL_ACCT_MATCHER_PROGRAM_OFF : ACCT_MATCHER_PROGRAM_OFF);
@@ -2112,7 +2133,12 @@ export function parseAccount(data: Uint8Array, idx: number): Account {
     reservedPnl: isAdl ? readU128LE(data, base + ACCT_RESERVED_PNL_OFF) : readU64LE(data, base + ACCT_RESERVED_PNL_OFF),
     warmupStartedAtSlot: readU64LE(data, base + warmupStartedOff),
     warmupSlopePerStep: readU128LE(data, base + warmupSlopeOff),
-    positionSize: readI128LE(data, base + positionSizeOff),
+    // V12_1 protocol replaced position_size + entry_price with position_basis_q.
+    // Pre-V12_1 layouts read the legacy position_size at positionFieldOff;
+    // V12_1 layouts read position_basis_q at the same offset slot but expose it
+    // via the dedicated positionBasisQ field instead, leaving positionSize as 0n.
+    positionSize: isV12_1 ? 0n : readI128LE(data, base + positionFieldOff),
+    positionBasisQ: isV12_1 ? readI128LE(data, base + positionFieldOff) : 0n,
     entryPrice: entryPriceOff >= 0 ? readU64LE(data, base + entryPriceOff) : 0n, // V12_1: entry_price removed
     // V12_1 changed funding_index from i128 to i64 (legacy field moved to end of account)
     fundingIndex: isV12_1 ? BigInt(readI64LE(data, base + fundingIndexOff)) : readI128LE(data, base + fundingIndexOff),

--- a/test/adl.test.ts
+++ b/test/adl.test.ts
@@ -99,7 +99,7 @@ describe("rankAdlPositions — unit tests on pure ranking logic", () => {
     const pos: AdlRankedPosition = {
       idx: 5,
       owner: CALLER,
-      positionSize: 1_000_000_000n,
+      positionSigned: 1_000_000_000n,
       pnl: 100_000n,
       capital: 1_000_000n,
       pnlPct: 1000n, // 10%
@@ -128,7 +128,7 @@ describe("rankAdlPositions — unit tests on pure ranking logic", () => {
     expect(result).toBe(0n);
   });
 
-  it("side is determined by positionSize sign", () => {
+  it("side is determined by positionSigned sign", () => {
     const longSize = 1_000n;
     const shortSize = -1_000n;
     expect(longSize > 0n ? "long" : "short").toBe("long");

--- a/test/devnet-getmarkets.test.ts
+++ b/test/devnet-getmarkets.test.ts
@@ -379,8 +379,8 @@ describe("devnet — fetchAdlRankedPositions() [PERC-8410]", () => {
         expect(typeof pos.idx).toBe("number");
         expect(pos.idx).toBeGreaterThanOrEqual(0);
         expect(pos.owner).toBeInstanceOf(PublicKey);
-        expect(typeof pos.positionSize).toBe("bigint");
-        expect(pos.positionSize).not.toBe(0n); // only non-zero positions are ranked
+        expect(typeof pos.positionSigned).toBe("bigint");
+        expect(pos.positionSigned).not.toBe(0n); // only non-zero positions are ranked
         expect(typeof pos.pnl).toBe("bigint");
         expect(typeof pos.capital).toBe("bigint");
         expect(typeof pos.pnlPct).toBe("bigint");

--- a/test/drift-check.test.ts
+++ b/test/drift-check.test.ts
@@ -456,10 +456,10 @@ describe("V12_1 slab — layout detection and field offsets", () => {
     expect(ownerBytes[31]).toBe(0xab);
   });
 
-  it.skip("parseAccount: account slot 0 — position_size at offset 88 (SBF) — TODO: rebuild mock with SBF layout (i128, reads i64 sentinel)", () => {
+  it.skip("parseAccount: account slot 0 — position_basis_q at offset 88 (SBF) — TODO: rebuild mock with SBF layout (i128, reads i64 sentinel)", () => {
     const account = parseAccount(slabBuf, 0);
     // We wrote 7_777_777 as i64 LE at acct+296 (only lo 8 bytes)
-    expect(account.positionSize).toBe(7_777_777n);
+    expect(account.positionBasisQ).toBe(7_777_777n);
   });
 
   it.skip("parseAccount: entry_price removed in V12_1 — TODO: remove test (u64)", () => {

--- a/test/integration-mocked.test.ts
+++ b/test/integration-mocked.test.ts
@@ -332,7 +332,7 @@ describe("fetchAdlRankedPositions — mocked RPC (PERC-8339)", () => {
     expect(longs.length).toBe(2);
     expect(shorts.length).toBe(1);
     expect(shorts[0].idx).toBe(1);
-    expect(longs.every(p => p.positionSize > 0n)).toBe(true);
+    expect(longs.every(p => p.positionSigned > 0n)).toBe(true);
   });
 
   it("isTriggered=true when pnlPosTot > maxPnlCap", async () => {

--- a/test/mainnet-harness.test.ts
+++ b/test/mainnet-harness.test.ts
@@ -309,6 +309,7 @@ describe(`PERC-8417: Mainnet Readiness Harness (${NETWORK_LABEL})`, () => {
         expect(idx).toBeGreaterThanOrEqual(0);
         expect(account.owner).toBeInstanceOf(PublicKey);
         expect(typeof account.positionSize).toBe("bigint");
+        expect(typeof account.positionBasisQ).toBe("bigint");
         expect(typeof account.capital).toBe("bigint");
       }
     });


### PR DESCRIPTION
## Summary

In the V12_1 protocol upgrade, the on-chain `Account` struct replaced `position_size` and `entry_price` with a single signed `i128 position_basis_q` field at offset 88. The SDK parser was already reading the correct bytes, but exposed them via `Account.positionSize`, which is semantically wrong: `position_basis_q` is a quote-denominated basis used for ADL tracking, not a lots-denominated position size, and the magnitudes are not comparable across the two layouts.

Consumers reading `account.positionSize` on a V12_1 account silently received the wrong value.

This PR separates the two semantically distinct fields so each layout exposes its data under the correct name.

## Changes

- **`Account.positionSize`** is now populated only for pre-V12_1 layouts. On V12_1+ accounts it is `0n`.
- **`Account.positionBasisQ`** is new, populated only for V12_1+ accounts. On pre-V12_1 accounts it is `0n`.
- **`AdlRankedPosition.positionSize`** is renamed to **`positionSigned`** to reflect that it carries whichever signed value the source layout provides; only its sign (long vs short) is used for ranking.
- `fetchAdlRankedPositions` now selects the populated field per layout (`positionBasisQ` for V12_1+, `positionSize` for older).
- The V12_1 offset constant is renamed `V12_1_ACCT_POSITION_SIZE_OFF` -> `V12_1_ACCT_POSITION_BASIS_Q_OFF` to make the truth visible at the parsing site.
- Tests touching the renamed fields are updated; mainnet harness now also asserts `positionBasisQ` shape.

## Behavior

No behavior change in ADL ranking: `fetchAdlRankedPositions` only depends on the **sign** of the field, which is consistent across both layouts (positive = long, negative = short).

This is a breaking change to the public `Account` and `AdlRankedPosition` types. The repo is at `1.0.0-beta.11` so pre-1.0 breaking changes are acceptable.

## Test plan

- [x] `npm run lint` (tsc --noEmit) passes
- [x] All `tsx` test files (`abi`, `slab`, `validation`, `dex-oracle`, `trading`, `warmup-leverage-cap`, `dynamic-fees`, `oracle`) pass on this branch
- [x] `vitest run` shows the same 14 failures on this branch as on `main` (no new failures introduced); pre-existing failures cluster on V12_1 layout detection in `test/drift-check.test.ts` and on a separate V1_LEGACY mock-slab issue in `test/integration-mocked.test.ts`
- [ ] Maintainer to verify on mainnet against a live V12_1 slab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for V12_1+ protocol accounts with proper position field handling across different protocol versions.

* **Bug Fixes**
  * Improved position ranking accuracy by using signed position values from protocol-specific fields instead of raw position sizes.

* **Tests**
  * Updated test cases to validate new position field behavior and side determination across account versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->