### PR TITLE
fix(slab): use engine-relative bitmap offset in buildLayoutV12_1

### DIFF
--- a/src/solana/slab.ts
+++ b/src/solana/slab.ts
@@ -1214,8 +1214,13 @@ function buildLayoutV12_1(maxAccounts: number, dataLen?: number): SlabLayout {
   const hostSize = computeSlabSize(V12_1_ENGINE_OFF, V12_1_ENGINE_BITMAP_OFF, V12_1_ACCOUNT_SIZE, maxAccounts, 18);
   const isSbf = dataLen !== undefined && dataLen !== hostSize;
   const engineOff = isSbf ? 616 : V12_1_ENGINE_OFF;
-  // SBF bitmap: engine+590 (abs 1206). Host: engine+368 (abs 1016).
-  const bitmapOff = isSbf ? 590 : (V12_1_ENGINE_BITMAP_OFF - V12_1_ENGINE_OFF);
+  // Engine-relative bitmap offset. Host=1016 (matches V12_1_ENGINE_BITMAP_OFF
+  // convention used by computeSlabSize, buildLayoutVADL, and buildLayoutVSetDexPool).
+  // SBF=590 (different struct alignment under cargo build-sbf).
+  // NOTE: A prior change here subtracted V12_1_ENGINE_OFF from the host value,
+  // which broke V12_1 host accountsOff (parser produced 9744 instead of 10392
+  // for the large tier and miscomputed every per-field offset downstream).
+  const bitmapOff = isSbf ? 590 : V12_1_ENGINE_BITMAP_OFF;
   const accountSize = isSbf ? V12_1_ACCOUNT_SIZE_SBF : V12_1_ACCOUNT_SIZE;
   const bitmapWords = Math.ceil(maxAccounts / 64);
   const bitmapBytes = bitmapWords * 8;


### PR DESCRIPTION
## Summary

`buildLayoutV12_1` was subtracting `V12_1_ENGINE_OFF` from `V12_1_ENGINE_BITMAP_OFF` when computing the host bitmap offset, treating the constant as slab-absolute. The convention used everywhere else in the file (`computeSlabSize`, `buildLayoutVADL`, `buildLayoutVSetDexPool`, the `SLAB_TIERS_V12_1` registration) treats `*_ENGINE_BITMAP_OFF` as **engine-relative**. The drift-check test mock makes this explicit: `BITMAP_OFF_REL = 1016; // relative to ENGINE_OFF`.

The subtraction caused `buildLayoutV12_1` to compute `preAccountsLen` with `368` (= `1016 - 648`) instead of `1016` for V12_1 host slabs, producing `accountsOff = 9744` instead of `10392` for the large tier. Every per-field offset downstream (`owner`, `fundingIndex`, `accountId`, `capital`, `positionSize`/`positionBasisQ`) was then read from the wrong slab byte.

The bug was introduced by commit `8f3a123` ("V12_1 SBF engineOff=616...") when SBF support was added: the SBF branch correctly uses an engine-relative value (`590`), but the host branch was rewritten with a mistaken absolute-to-relative conversion that the convention does not require.

## Changes

- `src/solana/slab.ts:1218` — drop the `- V12_1_ENGINE_OFF` subtraction in the host branch; the SBF branch is left untouched.
- Comment updated to document the engine-relative convention and the prior regression.

## Behavior

- `accountsOff` for V12_1 large host slabs: `9744` -> `10392` (matches the registered tier size `1321112` and the on-chain mainnet layout).
- `accountsOff` for V12_1 small host slabs: matches the test expectation of `2232`.
- Per-field offsets in `parseAccount` for V12_1 host accounts now read from the correct positions.

## Test plan

- [x] `npm run lint` (`tsc --noEmit`) passes
- [x] `npx tsx test/slab.test.ts` — V12_1 layout section now passes (was failing on main)
- [x] `npx vitest run test/drift-check.test.ts` — all 46 tests pass; the 6 previously failing V12_1 assertions (`accountsOff for small (256 accts) is 2232`, `detectLayout delegates to layout.accountsOff`, `parseAccount: owner at relative offset 208`, `parseAccount: fundingIndex at relative offset 288`, `parseAccount: accountId is 42`, `parseAccount: capital is 1_000_000`) are now green.
- [x] Full vitest suite: 14 failures on `main` -> 8 failures on this branch. The 6 fixed are exactly the V12_1 drift-check assertions; zero new failures introduced. The remaining 8 failures all in `test/integration-mocked.test.ts` are pre-existing on `main` (V1_LEGACY mock-slab issues unrelated to this fix).
- [ ] Maintainer to verify on mainnet against a live V12_1 slab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected bitmap offset calculations for V12.1 host tier accounts, fixing account offset computations and per-field account parsing. This resolves inconsistencies in how account data was being parsed for host environments and ensures alignment with account offset calculations used by other layout builders, improving overall system consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->