### PR TITLE
test(integration-mocked): fix stale maxPnlCap offset in V1 slab mock

### DIFF
--- a/test/integration-mocked.test.ts
+++ b/test/integration-mocked.test.ts
@@ -82,12 +82,14 @@ function buildV1SmallSlab(opts: {
 
   // maxPnlCap (u64 LE) — offset within config:
   //   3 pubkeys(96) + maxStaleness(8)+confFilter(2)+bump(1)+invert(1)+unitScale(4)=16
-  //   + 9 funding fields: 8+8+16+8+8+8+8+8+8=80
+  //   + 5 funding fields: 8+8+16+8+8=48 (V12_1 upstream rebase removed 4 deprecated
+  //     fields — fundingPremiumWeightBps, fundingSettlementIntervalSlots,
+  //     fundingPremiumDampeningE6, fundingPremiumMaxBpsPerSlot — see slab.ts:1724-1727)
   //   + 8 thresh fields: 16+8+8+8+8+16+16+16=96
   //   + oracleAuthority(32)+authorityPriceE6(8)+authorityTimestamp(8)=48
   //   + oraclePriceCapE2bps(8)+lastEffPriceE6(8)+oiCapMultiplierBps(8)=24
-  //   → 360 bytes before maxPnlCap → absolute = 104 + 360 = 464
-  dv.setBigUint64(464, opts.maxPnlCap ?? 0n, true);
+  //   → 328 bytes before maxPnlCap → absolute = 104 + 328 = 432
+  dv.setBigUint64(432, opts.maxPnlCap ?? 0n, true);
 
   // ---- ENGINE (V1_LEGACY: ENGINE_OFF=640, bitmapOff_actual=672) ----
   // SLAB_TIERS_V1M.small!.dataSize=65_352 → detectSlabLayout returns V1_LEGACY layout:


### PR DESCRIPTION
## Summary

The `buildV1SmallSlab()` test mock was writing `maxPnlCap` to absolute offset **464**, based on a stale assumption that `MarketConfig` contains 9 funding fields totalling 80 bytes. The V12_1 upstream rebase removed 4 deprecated funding fields (`fundingPremiumWeightBps`, `fundingSettlementIntervalSlots`, `fundingPremiumDampeningE6`, `fundingPremiumMaxBpsPerSlot`) — see [src/solana/slab.ts:1724-1727](src/solana/slab.ts#L1724-L1727) for the parser-side note explaining the removal. The current parser walks 5 funding fields = 48 bytes and reads `maxPnlCap` from absolute offset **432**.

The 32-byte gap between mock-write (464) and parser-read (432) caused `parseConfig` to return `maxPnlCap=0n` on the mock slab, which in turn made `isAdlTriggered()` and `rankAdlPositions()` report `isTriggered=false` on every test that exercised them.

This is purely a test-fixture fix — **no production code changes**.

## Changes

- `test/integration-mocked.test.ts:90` — write `maxPnlCap` to absolute offset `432` (was `464`); update the offset-derivation comment to match the current `MarketConfig` layout.

## Failing assertions resolved (7 of 8)

- `fetchAdlRankedPositions > isTriggered=true when pnlPosTot > maxPnlCap`
- `buildAdlTransaction > returns a valid instruction when ADL is triggered and positions exist`
- `buildAdlTransaction > picks highest pnlPct long as target (idx 3 > idx 7)`
- `buildAdlTransaction > preferSide=long targets highest pnlPct long`
- `buildAdlTransaction > instruction has correct account structure (4 keys: caller, slab, clock, oracle)`
- `buildAdlTransaction > encodes targetIdx > 255 correctly (u16 LE)`
- `isAdlTriggered + rankAdlPositions > isAdlTriggered returns true when pnlPosTot > maxPnlCap`

The remaining `discoverMarkets > collateral mint parsed from slab` failure has a separate root cause (the mock `getProgramAccounts` ignores the `dataSize` filter, causing layout misdetection across tier dispatch) and will be addressed in a follow-up PR.

## Test plan

- [x] `npm run lint` (`tsc --noEmit`) clean
- [x] `npx vitest run test/integration-mocked.test.ts`: 7 of 8 previously-failing tests now pass; only the unrelated `discoverMarkets > collateral mint` test still fails
- [x] Full `vitest run` on this branch: 14 failures on `main` -> 7 failures on this branch. The 7 fixed are exactly the maxPnlCap-dependent assertions; zero new failures introduced. The 6 V12_1 layout failures and the 1 `discoverMarkets` failure are unrelated to this fix and have their own follow-up PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration fixtures to reflect revised funding field structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->