### PR TITLE
test(integration-mocked): make discovery mock filter-aware and use V1M fixture

### DIFF
--- a/test/integration-mocked.test.ts
+++ b/test/integration-mocked.test.ts
@@ -38,11 +38,17 @@ import { detectSlabLayout } from "../src/solana/slab.js";
 // ============================================================================
 
 /**
- * Build a minimal but structurally valid V1M small slab (65_352 bytes).
+ * Build a minimal but structurally valid V1M small slab (65_416 bytes).
  *
- * SLAB_TIERS_V1M.small!.dataSize=65_352 maps to the V1M layout (mainnet program ESa89R5):
+ * SLAB_TIERS_V1M.small!.dataSize=65_416 maps to the V1M layout (mainnet program ESa89R5):
  *   ENGINE_OFF=640, CONFIG_LEN=536, BITMAP_OFF_REL=720, pnlPosTotOff=552
  *   accountsOff_abs=1928, bitmapAbs=1360, acctOwnerOff=184, acctPositionSizeOff=80
+ *
+ * V1M is in discovery's ALL_TIERS list (the older V1_LEGACY 65_352 size is
+ * only registered in V1_SIZES_LEGACY for read-only parsing of orphaned
+ * devnet slabs and is NOT discovered by getProgramAccounts tier filters).
+ * Using V1M small here keeps the mock fixture consistent with what the
+ * filter-aware test connection actually queries for.
  *
  * Only the bytes that affect the fields read by the SDK are filled.
  * The resulting buffer is accepted by detectSlabLayout, parseConfig,
@@ -54,9 +60,8 @@ function buildV1SmallSlab(opts: {
   /** List of user accounts to embed: idx, pnl, capital, positionSize */
   accounts?: Array<{ idx: number; pnl: bigint; capital: bigint; positionSize: bigint }>;
 } = {}): Uint8Array {
-  // V1_LEGACY small slab: 65,352 bytes (ENGINE_OFF=640, ACCOUNT_SIZE=248, BITMAP_OFF=672)
-  // The mock writes at V1_LEGACY offsets, so the size must match V1_LEGACY detection.
-  const size = 65_352;
+  // V1M small slab: 65,416 bytes (ENGINE_OFF=640, ACCOUNT_SIZE=248, BITMAP_OFF_REL=720)
+  const size = 65_416;
   const buf = Buffer.alloc(size, 0);
   const dv = new DataView(buf.buffer);
 
@@ -89,19 +94,19 @@ function buildV1SmallSlab(opts: {
   //   → 360 bytes before maxPnlCap → absolute = 104 + 360 = 464
   dv.setBigUint64(464, opts.maxPnlCap ?? 0n, true);
 
-  // ---- ENGINE (V1_LEGACY: ENGINE_OFF=640, bitmapOff_actual=672) ----
-  // SLAB_TIERS_V1M.small!.dataSize=65_352 → detectSlabLayout returns V1_LEGACY layout:
-  //   engineOff=640, pnlPosTotOff=504, bitmapOff_actual=672, accountsOff=1880, acctOwnerOff=200
-  // pnlPosTot u128 at absolute = 640 + 504 = 1144
+  // ---- ENGINE (V1M: ENGINE_OFF=640, bitmapOff_rel=720) ----
+  // SLAB_TIERS_V1M.small!.dataSize=65_416 → detectSlabLayout returns V1M layout:
+  //   engineOff=640, pnlPosTotOff=552, bitmapOff_rel=720, accountsOff=1928, acctOwnerOff=184
+  // pnlPosTot u128 at absolute = 640 + 552 = 1192
   if (opts.pnlPosTot !== undefined) {
-    writeBigUint128LE(buf, 1144, opts.pnlPosTot);
+    writeBigUint128LE(buf, 1192, opts.pnlPosTot);
   }
 
   // ---- ACCOUNTS ----
-  // V1_LEGACY small: accountsOff=1880, bitmapAbs=1312, acctOwnerOff=200
-  const ACCOUNTS_OFF = 1880;
+  // V1M small: accountsOff=1928, bitmapAbs=1360, acctOwnerOff=184
+  const ACCOUNTS_OFF = 1928;
   const ACCOUNT_SIZE = 248;
-  const BITMAP_ABS   = 1312; // 640 + 672
+  const BITMAP_ABS   = 1360; // 640 + 720
 
   for (const acct of (opts.accounts ?? [])) {
     const base = ACCOUNTS_OFF + acct.idx * ACCOUNT_SIZE;
@@ -111,9 +116,10 @@ function buildV1SmallSlab(opts: {
     buf[base + 24] = 0; // kind = User
     writeBigInt128LE(buf, base + 32, acct.pnl);             // pnl i128
     writeBigInt128LE(buf, base + 80, acct.positionSize);    // positionSize i128
-    // owner pubkey at acctOwnerOff=200 (V1_LEGACY!)
+    // owner pubkey at acctOwnerOff=184 (V1M parser reads from base+184; older
+    // V1_LEGACY mock wrote at +200 which the parser silently ignored).
     const ownerSeed = `ACCT${String(acct.idx).padStart(7, "0")}11111111111111111111111`;
-    buf.set(Buffer.from(ownerSeed.slice(0, 32)), base + 200);
+    buf.set(Buffer.from(ownerSeed.slice(0, 32)), base + 184);
     setBitmapBit(buf, BITMAP_ABS, acct.idx);
   }
 
@@ -162,8 +168,24 @@ function makeConnection(opts: {
         rentEpoch: 0,
       };
     },
-    getProgramAccounts: async (_programId: PublicKey, _config?: unknown) => {
-      return opts.programAccounts ?? [];
+    getProgramAccounts: async (
+      _programId: PublicKey,
+      config?: { filters?: Array<{ dataSize?: number; memcmp?: { offset: number; bytes: string } }> },
+    ) => {
+      // Filter-aware mock: when discoverMarkets queries by `dataSize`, only
+      // return entries whose actual data length matches. This mirrors how
+      // Solana RPC's getProgramAccounts behaves and prevents the test slab
+      // from being delivered to discoverMarkets tagged with the WRONG tier
+      // dataSize (which would cause detectSlabLayout to misidentify the
+      // layout and parseConfig to read garbage from the wrong configOffset).
+      // Filters without `dataSize` (e.g. the memcmp magic-bytes fallback)
+      // pass through unfiltered to preserve current behaviour.
+      const all = opts.programAccounts ?? [];
+      const dataSizeFilter = config?.filters?.find(f => f.dataSize !== undefined);
+      if (dataSizeFilter?.dataSize !== undefined) {
+        return all.filter(entry => entry.account.data.length === dataSizeFilter.dataSize);
+      }
+      return all;
     },
   } as unknown as Connection;
 }
@@ -207,9 +229,9 @@ describe("discoverMarkets — mocked RPC (PERC-8339)", () => {
     expect(markets[0].header.version).toBe(1);
   });
 
-  it("detects layout correctly for the V1 small slab fixture (65_352 bytes)", () => {
+  it("detects layout correctly for the V1M small slab fixture (65_416 bytes)", () => {
     const slabData = buildV1SmallSlab();
-    expect(slabData.length).toBe(65_352); // V1_LEGACY small
+    expect(slabData.length).toBe(65_416); // V1M small
     const layout = detectSlabLayout(slabData.length);
     expect(layout).not.toBeNull();
     expect(layout!.maxAccounts).toBe(256);


### PR DESCRIPTION
## Summary

The `makeConnection()` test helper's `getProgramAccounts()` ignored the `filter` argument and returned the same response for every tier query. `discoverMarkets` queries ~20 dataSize tiers in parallel, dedupes by pubkey, and uses whichever tier won the dedup race to drive the layout detection. With the previous fixture this caused the V1_LEGACY-style 65,352-byte mock slab to be tagged with V12_1 large dataSize (1,321,112), making `detectSlabLayout` return V12_1 layout (`configOffset=72`) and `parseConfig` read `collateralMint` from the wrong slab byte range — producing the all-zero pubkey `"11111111111111111111111111111111"` instead of the USDC mint the fixture wrote at offset 104.

This change has two parts that together restore realistic mock behaviour.

## Changes

**1. Filter-aware `getProgramAccounts` in `makeConnection`**

When `discoverMarkets` queries by `dataSize`, the mock now only returns entries whose actual `data.length` matches, mirroring how Solana RPC behaves. Filters without `dataSize` (e.g. the memcmp magic-bytes fallback) pass through unfiltered to preserve current behaviour.

**2. `buildV1SmallSlab` now produces a V1M small slab (65,416 bytes)**

The V1_LEGACY size (65,352) is only registered in `V1_SIZES_LEGACY` for read-only parsing of orphaned devnet slabs and is intentionally **not** in discovery's `ALL_TIERS` list, so a filter-aware mock would never deliver it. V1M small **is** in `ALL_TIERS` via `SLAB_TIERS_V1M`, so the filter-aware query path delivers the slab tagged with the correct `dataSize`.

The V1M fixture requires four offset updates inside `buildV1SmallSlab`:
- `size`: `65_352` → `65_416`
- `pnlPosTot` write offset: `1144` → `1192` (`engineOff + V1M pnlPosTotOff = 640 + 552`)
- bitmap absolute offset: `1312` → `1360` (`engineOff + V1M bitmapOffRel = 640 + 720`)
- `ACCOUNTS_OFF`: `1880` → `1928`

The owner write is also moved from `base + 200` to `base + 184` to match where the parser actually reads `acctOwnerOff` for V1M (the previous `+200` was a latent fixture bug — `parseAccount` reads from `+184` and the `+200` bytes were silently ignored).

The `detects layout correctly for the V1 small slab fixture` assertion is updated from `65_352` to `65_416` to match the new fixture size.

**This is a test-only change — no production code is touched.**

## Test plan

- [x] `npm run lint` (`tsc --noEmit`) clean
- [x] `npx vitest run test/integration-mocked.test.ts` — the previously-failing `discoverMarkets > correct collateral mint parsed from slab` assertion now passes
- [x] Full `vitest run`: 14 failures on `main` → 13 failures on this branch. The 1 fixed is exactly the discoverMarkets/collateralMint assertion. **Zero new failures introduced.** The remaining 13 failures break down as:
  - 6 V12_1 layout assertions in `test/drift-check.test.ts` — addressed by #169
  - 7 maxPnlCap-dependent assertions in `test/integration-mocked.test.ts` — addressed by #170
- [ ] Maintainer to verify against a real V1M-sized on-chain slab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test fixtures and mock RPC behavior to validate account filtering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->