### PR TITLE
docs(readme): fix stale function names in ABI encoding example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ const liqPrice = computeLiqPrice(entryPrice, capital, positionSize, 500n);
 Type-safe instruction builders matching the on-chain Rust layout byte-for-byte:
 
 ```typescript
-import { buildInitMarketIxData, buildTradeNoCpiIxData, IX_TAG } from "@percolator/sdk";
+import { encodeInitMarket, encodeTradeNoCpi, IX_TAG } from "@percolator/sdk";
 
 // Build InitMarket instruction data (256 bytes)
-const data = buildInitMarketIxData({
+const data = encodeInitMarket({
   admin: adminPubkey,
   collateralMint: mintPubkey,
   indexFeedId: pythFeedId,
@@ -82,7 +82,7 @@ const data = buildInitMarketIxData({
 });
 
 // Build trade instruction
-const tradeData = buildTradeNoCpiIxData({
+const tradeData = encodeTradeNoCpi({
   userIdx: 0,
   lpIdx: 0,
   requestedSize: 1_000_000n, // positive = long, negative = short


### PR DESCRIPTION
## Summary

The README's ABI encoding example used `buildInitMarketIxData` and `buildTradeNoCpiIxData`, which do not exist in the SDK. The actual exports are `encodeInitMarket` and `encodeTradeNoCpi` ([src/abi/instructions.ts:227](src/abi/instructions.ts#L227) and [:355](src/abi/instructions.ts#L355)). Users copying the example would get `"is not exported"` errors.

## Changes

- `README.md:70` — import statement: `buildInitMarketIxData, buildTradeNoCpiIxData` → `encodeInitMarket, encodeTradeNoCpi`
- `README.md:73` — function call: `buildInitMarketIxData({` → `encodeInitMarket({`
- `README.md:85` — function call: `buildTradeNoCpiIxData({` → `encodeTradeNoCpi({`

## Test plan

- [x] `npm run lint` (`tsc --noEmit`) clean
- [x] Verified `encodeInitMarket` and `encodeTradeNoCpi` are the actual exported names via grep
- [x] No remaining references to the stale names in README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README examples to reflect current API usage patterns for instruction data building operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->