### PR TITLE
fix(price-router): do not emit price=0 source on DEX/Jupiter disagreement

### DIFF
--- a/src/oracle/price-router.ts
+++ b/src/oracle/price-router.ts
@@ -315,26 +315,37 @@ export async function resolvePrice(
 
   // Add Pyth if available (highest priority for supported tokens)
   if (pythSource) {
-    // Enrich Pyth price from DEX and/or Jupiter — cross-validate when both exist
+    // Enrich Pyth price from DEX and/or Jupiter — cross-validate when both exist.
+    // If enrichment fails (sources disagree or no secondary source available),
+    // the unenriched Pyth source is NOT added to allSources. A price=0 source
+    // must never appear in the result: encodePushOraclePrice rejects price=0
+    // (division by zero in on-chain engine) and downstream math (computeMarkPnl,
+    // computeLiqPrice) produces undefined results.
     const dexPrice = dexSources[0]?.price ?? 0;
     const jupPrice = jupiterSource?.price ?? 0;
 
+    let enriched = false;
     if (dexPrice > 0 && jupPrice > 0) {
       // Cross-validate: reject if sources diverge by more than 50%
       const mid = (dexPrice + jupPrice) / 2;
       const deviation = Math.abs(dexPrice - jupPrice) / mid;
-      if (deviation > 0.5) {
-        // Sources disagree significantly — don't enrich Pyth, lower confidence
-        pythSource.price = 0;
-        pythSource.confidence = 20;
-      } else {
+      if (deviation <= 0.5) {
         pythSource.price = mid;
+        enriched = true;
       }
-    } else {
-      // Only one source available — use it but note reduced validation
-      pythSource.price = dexPrice || jupPrice || 0;
+      // If deviation > 0.5: sources disagree — skip enrichment. The DEX and
+      // Jupiter sources are still available in allSources at their own
+      // confidence levels for callers that want them.
+    } else if (dexPrice > 0 || jupPrice > 0) {
+      // Only one secondary source — use it with reduced confidence
+      pythSource.price = dexPrice || jupPrice;
+      pythSource.confidence = Math.min(pythSource.confidence, 50);
+      enriched = true;
     }
-    allSources.push(pythSource);
+
+    if (enriched) {
+      allSources.push(pythSource);
+    }
   }
 
   // Add DEX sources


### PR DESCRIPTION
## Summary

When Pyth/DEX cross-validation found sources diverging by >50%, the code at [src/oracle/price-router.ts:328](src/oracle/price-router.ts#L328) set `pythSource.price = 0` and pushed it into `allSources`. A zero price is catastrophic downstream:

- `encodePushOraclePrice` explicitly rejects `price === 0n` with `"division by zero in engine"` ([src/abi/instructions.ts:569](src/abi/instructions.ts#L569))
- `computeMarkPnl` divides by `oraclePrice` ([src/math/trading.ts:37](src/math/trading.ts#L37)), producing Infinity or NaN
- `computeLiqPrice` uses `oraclePrice` in its denominator

The previous code also set `pythSource.price = dexPrice || jupPrice || 0` when only one secondary source was available, silently defaulting to `0` when neither exists.

## Changes

Restructured the enrichment logic in `resolvePrice()` so that an unenriched (`price=0`) Pyth source is **never** added to `allSources`:

- **DEX + Jupiter agree** (deviation <= 50%): enrich Pyth with the midpoint price and add to `allSources` (unchanged behaviour).
- **DEX + Jupiter disagree** (deviation > 50%): **skip Pyth enrichment entirely.** The DEX and Jupiter sources are still available in `allSources` at their own confidence levels; `bestSource` will be the highest-confidence non-Pyth source rather than a poisoned zero.
- **Only one secondary source**: enrich Pyth with that price at reduced confidence (capped to 50), and add to `allSources`.
- **No secondary source**: Pyth is not enrichable and is **not added** (was previously added with `price=0`).

This eliminates the `price=0` propagation path without changing the 50% deviation threshold itself (tightening the threshold is a separate design decision).

## Test plan

- [x] `npm run lint` (`tsc --noEmit`) clean
- [x] `npx vitest run test/price-router.test.ts` — all 22 tests pass
- [x] Full `vitest run`: same 14 pre-existing failures as `main`, zero new failures
- [ ] Add tests for the >50% disagreement and no-secondary-source paths (recommended follow-up)