### PR TITLE
fix(slab): remove phantom funding fields from MarketConfig interface

### DIFF
--- a/src/solana/slab.ts
+++ b/src/solana/slab.ts
@@ -1437,10 +1437,6 @@ export interface MarketConfig {
   fundingInvScaleNotionalE6: bigint;
   fundingMaxPremiumBps: bigint;
   fundingMaxBpsPerSlot: bigint;
-  /** @deprecated Removed in V12_1 — always 0 */ fundingPremiumWeightBps: bigint;
-  /** @deprecated Removed in V12_1 — always 0 */ fundingSettlementIntervalSlots: bigint;
-  /** @deprecated Removed in V12_1 — always 0 */ fundingPremiumDampeningE6: bigint;
-  /** @deprecated Removed in V12_1 — always 0 */ fundingPremiumMaxBpsPerSlot: bigint;
   threshFloor: bigint;
   threshRiskBps: bigint;
   threshUpdateIntervalSlots: bigint;
@@ -1852,10 +1848,6 @@ export function parseConfig(data: Uint8Array, layoutHint?: SlabLayout | null): M
     fundingInvScaleNotionalE6,
     fundingMaxPremiumBps,
     fundingMaxBpsPerSlot,
-    fundingPremiumWeightBps: 0n,
-    fundingSettlementIntervalSlots: 0n,
-    fundingPremiumDampeningE6: 0n,
-    fundingPremiumMaxBpsPerSlot: 0n,
     threshFloor,
     threshRiskBps,
     threshUpdateIntervalSlots,


### PR DESCRIPTION
## Summary

The V12_1 upstream rebase removed four funding fields from the on-chain `MarketConfig` struct. The parser at [src/solana/slab.ts:1724-1727](src/solana/slab.ts#L1724-L1727) already documents this removal and does not read them. However, the `MarketConfig` TypeScript interface still declared all four as `bigint` fields with `@deprecated` annotations, and `parseConfig` returned them as `0n`.

This is not just cosmetic: the fields appeared in the `.d.ts` type definitions, so TypeScript consumers could still reference them without compiler error — getting silent `0n` instead of a type error. Previous beta releases (beta.9, beta.10) had recurring bugs around these fields leaking into the dist.

## Changes

Removed from `MarketConfig` interface and `parseConfig` return object:
- `fundingPremiumWeightBps`
- `fundingSettlementIntervalSlots`
- `fundingPremiumDampeningE6`
- `fundingPremiumMaxBpsPerSlot`

This is a breaking change to the public type. The repo is at `1.0.0-beta.11` so pre-1.0 breaking changes are acceptable.

## Test plan

- [x] `npm run lint` (`tsc --noEmit`) clean — no test/example/src consumer references these fields
- [x] Full `vitest run`: same 14 pre-existing failures as `main`, zero new failures
- [x] Verified via grep: no test, example, or README file references any of the four fields