### PR TITLE
docs(readme): sync version badge to 1.0.0-beta.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 TypeScript SDK for building clients, bots, and UIs on top of the [Percolator](https://github.com/dcccrypto/percolator) perpetual futures protocol on Solana.
 
-> **⚠️ BETA** — `1.0.0-beta.1`. Security audit (0x-SquidSol) complete. All 709 tests passing. Pending Helius API key + mainnet market deployment before `1.0.0` stable.
+> **⚠️ BETA** — `1.0.0-beta.11`. Security audit (0x-SquidSol) complete. Pending Helius API key + mainnet market deployment before `1.0.0` stable.
 
 [![npm](https://img.shields.io/npm/v/@percolator/sdk?color=14F195)](https://www.npmjs.com/package/@percolator/sdk)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)


### PR DESCRIPTION
## Summary

README claimed `1.0.0-beta.1` while `package.json` is at `1.0.0-beta.11` (10 releases out of sync). Also removed the stale "All 709 tests passing" claim since the test count has changed across beta releases.

## Changes

- `README.md:5` — version `1.0.0-beta.1` → `1.0.0-beta.11`, removed hardcoded test count

## Test plan

- [x] `npm run lint` clean