### PR TITLE
fix(slab): store correct engineBitmapOff for V12_1 SBF slabs

### DIFF
--- a/src/solana/slab.ts
+++ b/src/solana/slab.ts
@@ -1268,7 +1268,11 @@ function buildLayoutV12_1(maxAccounts: number, dataLen?: number): SlabLayout {
     engineEmergencyOiModeOff: V12_1_ENGINE_EMERGENCY_OI_MODE_OFF,
     engineEmergencyStartSlotOff: V12_1_ENGINE_EMERGENCY_START_SLOT_OFF,
     engineLastBreakerSlotOff: V12_1_ENGINE_LAST_BREAKER_SLOT_OFF,
-    engineBitmapOff: V12_1_ENGINE_BITMAP_OFF,
+    // engineBitmapOff must be engine-relative (see interface comment at line 131).
+    // SBF bitmap is at engine+590; host bitmap is at engine+1016 (V12_1_ENGINE_BITMAP_OFF).
+    // Storing the constant directly was correct for host but wrong for SBF — SBF
+    // slabs would compute parseUsedIndices base = 616+1016=1632 instead of 616+590=1206.
+    engineBitmapOff: isSbf ? 590 : V12_1_ENGINE_BITMAP_OFF,
     postBitmap: 18,
     acctOwnerOff: V12_1_ACCT_OWNER_OFF,
 


### PR DESCRIPTION
## Summary

`buildLayoutV12_1` stored `V12_1_ENGINE_BITMAP_OFF` (1016) in the returned `SlabLayout.engineBitmapOff` field for **both** host and SBF paths. The field contract ([SlabLayout interface, line 131](src/solana/slab.ts#L131): `// relative to engineOff`) requires an engine-relative value. For host V12_1 slabs, 1016 is correct (bitmap is at engine + 1016). For SBF V12_1 slabs, the bitmap is at engine + 590 — but the layout was storing 1016.

This caused `parseUsedIndices`, `isAccountUsed`, and `parseAllAccounts` to compute the wrong absolute bitmap offset on SBF V12_1 slabs:

- **Wrong:** `engineOff(616) + engineBitmapOff(1016) = 1632`
- **Correct:** `engineOff(616) + engineBitmapOff(590) = 1206`

All three functions read bitmap words from the corrupted offset, producing incorrect used-account indices and breaking account enumeration on SBF-built V12_1 slabs.

## Relationship to PR #169

This is a **separate** bug from PR #169, which fixed the internal `bitmapOff` variable used for `accountsOff` computation within `buildLayoutV12_1`. That variable is local to the function and does not affect the `engineBitmapOff` field stored in the returned `SlabLayout` object. PR #169 fixed `accountsOff`; this PR fixes bitmap parsing.

## Changes

- [src/solana/slab.ts:1271](src/solana/slab.ts#L1271) — use `isSbf ? 590 : V12_1_ENGINE_BITMAP_OFF` instead of unconditional `V12_1_ENGINE_BITMAP_OFF`

## Test plan

- [x] `npm run lint` (`tsc --noEmit`) clean
- [x] Full `vitest run`: same 14 pre-existing failures as `main`, zero new failures
- [ ] Add tests for `parseUsedIndices` and `isAccountUsed` on V12_1 SBF slabs (recommended follow-up — no test currently exercises SBF bitmap parsing)