### PR TITLE
fix(stake): accept tokenProgramId parameter in account builders

### DIFF
--- a/src/solana/stake.ts
+++ b/src/solana/stake.ts
@@ -500,8 +500,13 @@ export interface StakeAccounts {
 /**
  * Build account keys for InitPool instruction.
  * Returns array of {pubkey, isSigner, isWritable} in the order the program expects.
+ *
+ * @param a - Account public keys.
+ * @param tokenProgramId - Token program to use. Defaults to `TOKEN_PROGRAM_ID`
+ *   (SPL Token). Pass `TOKEN_2022_PROGRAM_ID` if the collateral or LP mint is
+ *   owned by Token-2022.
  */
-export function initPoolAccounts(a: StakeAccounts['initPool']) {
+export function initPoolAccounts(a: StakeAccounts['initPool'], tokenProgramId: PublicKey = TOKEN_PROGRAM_ID) {
   return [
     { pubkey: a.admin, isSigner: true, isWritable: true },
     { pubkey: a.slab, isSigner: false, isWritable: false },
@@ -511,7 +516,7 @@ export function initPoolAccounts(a: StakeAccounts['initPool']) {
     { pubkey: a.vaultAuth, isSigner: false, isWritable: false },
     { pubkey: a.collateralMint, isSigner: false, isWritable: false },
     { pubkey: a.percolatorProgram, isSigner: false, isWritable: false },
-    { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+    { pubkey: tokenProgramId, isSigner: false, isWritable: false },
     { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
     { pubkey: SYSVAR_RENT_PUBKEY, isSigner: false, isWritable: false },
   ];
@@ -519,8 +524,10 @@ export function initPoolAccounts(a: StakeAccounts['initPool']) {
 
 /**
  * Build account keys for Deposit instruction.
+ *
+ * @param tokenProgramId - Token program to use. Defaults to `TOKEN_PROGRAM_ID`.
  */
-export function depositAccounts(a: StakeAccounts['deposit']) {
+export function depositAccounts(a: StakeAccounts['deposit'], tokenProgramId: PublicKey = TOKEN_PROGRAM_ID) {
   return [
     { pubkey: a.user, isSigner: true, isWritable: false },
     { pubkey: a.pool, isSigner: false, isWritable: true },
@@ -530,7 +537,7 @@ export function depositAccounts(a: StakeAccounts['deposit']) {
     { pubkey: a.userLpAta, isSigner: false, isWritable: true },
     { pubkey: a.vaultAuth, isSigner: false, isWritable: false },
     { pubkey: a.depositPda, isSigner: false, isWritable: true },
-    { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+    { pubkey: tokenProgramId, isSigner: false, isWritable: false },
     { pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: false },
     { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
   ];
@@ -538,8 +545,10 @@ export function depositAccounts(a: StakeAccounts['deposit']) {
 
 /**
  * Build account keys for Withdraw instruction.
+ *
+ * @param tokenProgramId - Token program to use. Defaults to `TOKEN_PROGRAM_ID`.
  */
-export function withdrawAccounts(a: StakeAccounts['withdraw']) {
+export function withdrawAccounts(a: StakeAccounts['withdraw'], tokenProgramId: PublicKey = TOKEN_PROGRAM_ID) {
   return [
     { pubkey: a.user, isSigner: true, isWritable: false },
     { pubkey: a.pool, isSigner: false, isWritable: true },
@@ -549,15 +558,17 @@ export function withdrawAccounts(a: StakeAccounts['withdraw']) {
     { pubkey: a.userCollateralAta, isSigner: false, isWritable: true },
     { pubkey: a.vaultAuth, isSigner: false, isWritable: false },
     { pubkey: a.depositPda, isSigner: false, isWritable: true },
-    { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+    { pubkey: tokenProgramId, isSigner: false, isWritable: false },
     { pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: false },
   ];
 }
 
 /**
  * Build account keys for FlushToInsurance instruction.
+ *
+ * @param tokenProgramId - Token program to use. Defaults to `TOKEN_PROGRAM_ID`.
  */
-export function flushToInsuranceAccounts(a: StakeAccounts['flushToInsurance']) {
+export function flushToInsuranceAccounts(a: StakeAccounts['flushToInsurance'], tokenProgramId: PublicKey = TOKEN_PROGRAM_ID) {
   return [
     { pubkey: a.caller, isSigner: true, isWritable: false },
     { pubkey: a.pool, isSigner: false, isWritable: true },
@@ -566,6 +577,6 @@ export function flushToInsuranceAccounts(a: StakeAccounts['flushToInsurance']) {
     { pubkey: a.slab, isSigner: false, isWritable: true },
     { pubkey: a.wrapperVault, isSigner: false, isWritable: true },
     { pubkey: a.percolatorProgram, isSigner: false, isWritable: false },
-    { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+    { pubkey: tokenProgramId, isSigner: false, isWritable: false },
   ];
 }


### PR DESCRIPTION
## Summary

`initPoolAccounts`, `depositAccounts`, `withdrawAccounts`, and `flushToInsuranceAccounts` all hardcoded `TOKEN_PROGRAM_ID` (SPL Token). If the collateral mint or LP mint is owned by Token-2022 (`TOKEN_2022_PROGRAM_ID`), all token operations (create, transfer, burn) would fail because the wrong token program is referenced in the instruction account list.

## Changes

Each function now accepts an optional `tokenProgramId` parameter that defaults to `TOKEN_PROGRAM_ID` for backward compatibility:

```typescript
// Before
export function depositAccounts(a: StakeAccounts['deposit']) { ... }

// After
export function depositAccounts(a: StakeAccounts['deposit'], tokenProgramId: PublicKey = TOKEN_PROGRAM_ID) { ... }
```

Updated functions:
- `initPoolAccounts` ([stake.ts:504](src/solana/stake.ts#L504))
- `depositAccounts` ([stake.ts:523](src/solana/stake.ts#L523))
- `withdrawAccounts` ([stake.ts:542](src/solana/stake.ts#L542))
- `flushToInsuranceAccounts` ([stake.ts:560](src/solana/stake.ts#L560))

This is a **non-breaking** change — existing callers that omit the parameter get the same behaviour as before.

## Test plan

- [x] `npm run lint` (`tsc --noEmit`) clean
- [x] Full `vitest run`: same 14 pre-existing failures as `main`, zero new failures
- [x] Existing stake tests pass (no changes needed — they use SPL Token mints)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced stake account configuration and initialization functions to accept optional token program selection parameters. Developers can now specify custom token program implementations for their specific integration needs, providing greater flexibility and control. These updates maintain complete backward compatibility, with default behavior unchanged for existing implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->