### PR TITLE
fix(trading): compute pre-trade liq fee on notional value, not raw position size

### DIFF
--- a/src/math/trading.ts
+++ b/src/math/trading.ts
@@ -108,7 +108,12 @@ export function computePreTradeLiqPrice(
 ): bigint {
   if (oracleE6 === 0n || margin === 0n || posSize === 0n) return 0n;
   const absPos = posSize < 0n ? -posSize : posSize;
-  const fee = (absPos * feeBps) / 10000n;
+  // Fee is on notional value (position × price), not raw position size.
+  // Notional in native units = absPos * oracleE6 / 1_000_000 (because oracleE6
+  // is price-per-unit scaled by 1e6). This matches the on-chain fee calculation
+  // and is consistent with computeTradingFee which expects notional as input.
+  const notional = (absPos * oracleE6) / 1_000_000n;
+  const fee = (notional * feeBps) / 10000n;
   const effectiveCapital = margin > fee ? margin - fee : 0n;
   const signedPos = direction === "long" ? absPos : -absPos;
   return computeLiqPrice(oracleE6, effectiveCapital, signedPos, maintBps);


### PR DESCRIPTION
## Summary

`computePreTradeLiqPrice` applied the trading fee (`feeBps`) to the raw position size instead of the notional value (position × oracle price). Trading fees on perp DEXes are assessed on notional, not lots.

**Impact example** — 100M-unit position at $100 with 30 bps fee:
- **Old (wrong):** `fee = 100_000_000 * 30 / 10000 = 300,000`
- **New (correct):** `fee = (100_000_000 * 100_000_000 / 1e6) * 30 / 10000 = 30,000,000`

The old formula underestimated fees by a factor proportional to the oracle price (in e6 scale / 10,000). This caused liquidation price estimates to be **overly optimistic** — users would be liquidated sooner than the SDK predicted because the fee deduction from effective capital was too small.

## Changes

- [src/math/trading.ts:111](src/math/trading.ts#L111) — compute `notional = (absPos * oracleE6) / 1_000_000n` first, then apply `fee = (notional * feeBps) / 10000n`. This is consistent with the existing `computeTradingFee` function which also expects notional as its base.

## Test plan

- [x] `npm run lint` (`tsc --noEmit`) clean
- [x] `npx tsx test/trading.test.ts` — all 50 tests pass. Existing assertions check directional relationships (`withFee > noFee` for longs, `withFee < noFee` for shorts) rather than exact values, so they pass with the corrected fee magnitude.
- [x] Full `vitest run`: same 14 pre-existing failures as `main`, zero new failures
- [ ] Recommended follow-up: add test cases with exact expected liq prices to prevent regression on the fee base