### PR TITLE
fix(accounts): mark admin as writable in state-mutation account specs

### DIFF
--- a/src/abi/accounts.ts
+++ b/src/abi/accounts.ts
@@ -362,7 +362,7 @@ export const ACCOUNTS_FUND_MARKET_INSURANCE: readonly AccountSpec[] = [
  * Set max % of global fund this market can access.
  */
 export const ACCOUNTS_SET_INSURANCE_ISOLATION: readonly AccountSpec[] = [
-  { name: "admin", signer: true, writable: false },
+  { name: "admin", signer: true, writable: true },
   { name: "slab", signer: false, writable: true },
 ] as const;
 
@@ -498,7 +498,7 @@ export const ACCOUNTS_TOPUP_KEEPER_FUND: readonly AccountSpec[] = [
  * Sets the OI imbalance hard-block threshold (admin only)
  */
 export const ACCOUNTS_SET_OI_IMBALANCE_HARD_BLOCK: readonly AccountSpec[] = [
-  { name: "admin", signer: true, writable: false },
+  { name: "admin", signer: true, writable: true },
   { name: "slab", signer: false, writable: true },
 ] as const;
 
@@ -583,7 +583,7 @@ export const ACCOUNTS_CLEAR_PENDING_SETTLEMENT: readonly AccountSpec[] = [
  * Sets the per-wallet position cap (admin only). capE6=0 disables.
  */
 export const ACCOUNTS_SET_WALLET_CAP: readonly AccountSpec[] = [
-  { name: "admin", signer: true, writable: false },
+  { name: "admin", signer: true, writable: true },
   { name: "slab", signer: false, writable: true },
 ] as const;
 


### PR DESCRIPTION
## Summary

Three admin-signed state-mutation account specs marked admin as `writable: false` while all 13 other admin specs use `writable: true`:

- `ACCOUNTS_SET_INSURANCE_ISOLATION` ([accounts.ts:365](src/abi/accounts.ts#L365))
- `ACCOUNTS_SET_OI_IMBALANCE_HARD_BLOCK` ([accounts.ts:501](src/abi/accounts.ts#L501))
- `ACCOUNTS_SET_WALLET_CAP` ([accounts.ts:586](src/abi/accounts.ts#L586))

All three instructions modify the slab (`writable: true` on the slab account), confirming they are state-mutating operations. Transactions built with the old specs could fail runtime validation if the on-chain program needs the admin account to be writable.

## Changes

Set `writable: true` on the admin account in all three specs.

## Test plan

- [x] `npm run lint` clean
- [x] Full `vitest run`: same 14 pre-existing failures, zero new failures