### PR TITLE
fix(discovery): use actual slab size in memcmp fallback, not hardcoded V12_1 large

### DIFF
--- a/src/solana/discovery.ts
+++ b/src/solana/discovery.ts
@@ -685,6 +685,10 @@ export async function discoverMarkets(
     // account size changed; RPC returns no error, so we must fallback on empty results too.
     if (rawAccounts.length === 0) {
       console.warn("[discoverMarkets] dataSize filters returned 0 markets, falling back to memcmp");
+      // Fetch full account data (no dataSlice) so we can use data.length as
+      // the actual slab size for layout detection. The previous code used
+      // dataSlice + hardcoded maxAccounts=4096 / dataSize=V12_1.large, which
+      // caused detectSlabLayout to fail for any slab that wasn't V12_1 large.
       const fallback = await connection.getProgramAccounts(programId, {
         filters: [
           {
@@ -694,10 +698,16 @@ export async function discoverMarkets(
             },
           },
         ],
-        dataSlice: { offset: 0, length: HEADER_SLICE_LENGTH },
       });
-      // Unknown actual size — use large V0 as safe default (maxAccounts=4096)
-      rawAccounts = [...fallback].map(e => ({ ...e, maxAccounts: 4096, dataSize: SLAB_TIERS.large.dataSize })) as RawEntry[];
+      rawAccounts = [...fallback].map(e => {
+        const actualSize = e.account.data.length;
+        const layout = detectSlabLayout(actualSize, new Uint8Array(e.account.data));
+        return {
+          ...e,
+          maxAccounts: layout?.maxAccounts ?? 4096,
+          dataSize: actualSize,
+        };
+      }) as RawEntry[];
     }
   } catch (err) {
     console.warn(
@@ -714,9 +724,16 @@ export async function discoverMarkets(
             },
           },
         ],
-        dataSlice: { offset: 0, length: HEADER_SLICE_LENGTH },
       });
-      rawAccounts = [...fallback].map(e => ({ ...e, maxAccounts: 4096, dataSize: SLAB_TIERS.large.dataSize })) as RawEntry[];
+      rawAccounts = [...fallback].map(e => {
+        const actualSize = e.account.data.length;
+        const layout = detectSlabLayout(actualSize, new Uint8Array(e.account.data));
+        return {
+          ...e,
+          maxAccounts: layout?.maxAccounts ?? 4096,
+          dataSize: actualSize,
+        };
+      }) as RawEntry[];
     } catch (memcmpErr) {
       // GH#59: memcmp also rejected (public mainnet RPCs reject all getProgramAccounts)
       console.warn(


### PR DESCRIPTION
## Summary

Both memcmp fallback paths in `discoverMarkets` hardcoded `maxAccounts: 4096` and `dataSize: SLAB_TIERS.large.dataSize` for all returned accounts. This caused `detectSlabLayout` to fail for any slab that wasn't V12_1 large, silently dropping valid markets with an "unrecognized layout" warning.

The root cause: memcmp queries used `dataSlice` (1940 bytes), making `data.length` always 1940. The fake `dataSize` hint then fed a V12_1-large size to `detectSlabLayout`, which only matches actual V12_1-large slabs.

## Changes

- [src/solana/discovery.ts:686-710](src/solana/discovery.ts#L686-L710) — removed `dataSlice` from the empty-result memcmp fallback; detect layout from actual `data.length`
- [src/solana/discovery.ts:717-740](src/solana/discovery.ts#L717-L740) — same fix for the error-catch memcmp fallback

Both paths now use `detectSlabLayout(data.length, data)` to derive `maxAccounts` and `dataSize` from the actual slab data.

## Trade-off

Higher bandwidth for the memcmp path (full slab data vs 1940-byte slice). Acceptable because this is already a last-resort fallback (tiers 1 and 2 both failed), and correct layout detection is worth the extra bytes.

## Test plan

- [x] `npm run lint` clean
- [x] Full `vitest run`: same 14 pre-existing failures, zero new failures
- [ ] Recommended: add test covering memcmp fallback with non-large slab sizes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved market discovery fallback logic when initial queries return no results. The system now fetches complete market data and dynamically calculates account sizing for better accuracy, replacing previously hardcoded size assumptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->