### PR TITLE
fix(slab): export V12.1 SBF tier sizes for mainnet discovery

### DIFF
--- a/src/solana/discovery.ts
+++ b/src/solana/discovery.ts
@@ -8,6 +8,7 @@ import {
   SLAB_TIERS_V2,
   SLAB_TIERS_V_ADL,
   SLAB_TIERS_V12_1,
+  SLAB_TIERS_V12_1_SBF,
   type SlabHeader,
   type MarketConfig,
   type EngineState,
@@ -60,14 +61,16 @@ const MAGIC_BYTES = new Uint8Array([0x54, 0x41, 0x4c, 0x4f, 0x43, 0x52, 0x45, 0x
  *          in SLAB_TIERS_V0 for discovery of legacy on-chain accounts.
  */
 /**
- * Default slab tiers for the current mainnet program (v12.1).
- * These are used by useCreateMarket to allocate slab accounts of the correct size.
+ * Default slab tiers for the current mainnet program (v12.1 SBF).
+ * These match the deployed SBF binary's struct layout (engineOff=616, accountSize=280).
+ * Used by useCreateMarket to allocate slab accounts of the correct size.
+ * SLAB_TIERS_V12_1 (HOST/aarch64) is kept for test builds.
  */
 export const SLAB_TIERS = {
-  micro:  SLAB_TIERS_V12_1["micro"],
-  small:  SLAB_TIERS_V12_1["small"],
-  medium: SLAB_TIERS_V12_1["medium"],
-  large:  SLAB_TIERS_V12_1["large"],
+  micro:  SLAB_TIERS_V12_1_SBF["micro"],
+  small:  SLAB_TIERS_V12_1_SBF["small"],
+  medium: SLAB_TIERS_V12_1_SBF["medium"],
+  large:  SLAB_TIERS_V12_1_SBF["large"],
 } as const;
 
 /** @deprecated V0 slab sizes — kept for backward compatibility with old on-chain slabs */
@@ -585,7 +588,8 @@ export async function discoverMarkets(
   // GH#1234) must also be included; omitting them causes legacy on-chain slabs to be missed by
   // dataSize filter queries and fall through to memcmp with wrong maxAccounts hint.
   const ALL_TIERS = [
-    ...Object.values(SLAB_TIERS),
+    ...Object.values(SLAB_TIERS),           // V12.1 SBF (mainnet deployed)
+    ...Object.values(SLAB_TIERS_V12_1),     // V12.1 HOST (test builds)
     ...Object.values(SLAB_TIERS_V0),
     ...Object.values(SLAB_TIERS_V1D),
     ...Object.values(SLAB_TIERS_V1D_LEGACY),

--- a/src/solana/slab.ts
+++ b/src/solana/slab.ts
@@ -1172,6 +1172,21 @@ for (const [label, n] of [["Micro", 64], ["Small", 256], ["Medium", 1024], ["Lar
 }
 
 /**
+ * V12_1 slab tier sizes for the deployed SBF binary (mainnet).
+ * ENGINE_OFF=616, BITMAP_OFF=584 (relative to engine), ACCOUNT_SIZE=280.
+ * Verified by cargo build-sbf compile-time offset_of! assertions.
+ * Use these (not SLAB_TIERS_V12_1) for on-chain allocation and discovery.
+ */
+export const SLAB_TIERS_V12_1_SBF: Record<string, { maxAccounts: number; dataSize: number; label: string; description: string }> = {};
+for (const [label, n] of [["Micro", 64], ["Small", 256], ["Medium", 1024], ["Large", 4096]] as const) {
+  const bitmapBytes = Math.ceil(n / 64) * 8;
+  const preAccLen = V12_1_SBF_BITMAP_OFF + bitmapBytes + 18 + n * 2;
+  const accountsOff = Math.ceil(preAccLen / 8) * 8;
+  const size = V12_1_SBF_ENGINE_OFF + accountsOff + n * V12_1_SBF_ACCOUNT_SIZE;
+  SLAB_TIERS_V12_1_SBF[label.toLowerCase()] = { maxAccounts: n, dataSize: size, label, description: `${n} slots (v12.1 SBF)` };
+}
+
+/**
  * Build a SlabLayout for V_SETDEXPOOL slabs (PERC-SetDexPool security fix).
  * ENGINE_OFF=632 (+8 from V_ADL=624 due to CONFIG_LEN growing 520→528).
  * All engine and account field offsets are identical to V_ADL.

--- a/test/discovery.test.ts
+++ b/test/discovery.test.ts
@@ -13,6 +13,7 @@ import {
   SLAB_TIERS_V2,
   SLAB_TIERS_V1M,
   SLAB_TIERS_V_ADL,
+  SLAB_TIERS_V12_1,
 } from "../src/solana/slab.js";
 
 // ============================================================================
@@ -434,6 +435,7 @@ describe("discoverMarkets — sequential mode (PERC-1650)", () => {
     // Each tier got exactly ONE call (no retry on non-429)
     const allTierCount =
       Object.keys(SLAB_TIERS).length +
+      Object.keys(SLAB_TIERS_V12_1).length +
       Object.keys(SLAB_TIERS_V0).length +
       Object.keys(SLAB_TIERS_V1D).length +
       Object.keys(SLAB_TIERS_V1D_LEGACY).length +


### PR DESCRIPTION
## Summary
- `SLAB_TIERS_V12_1` computes sizes using HOST/aarch64 constants (`engineOff=648`, `accountSize=320`) but mainnet deploys the SBF binary (`engineOff=616`, `accountSize=280`)
- Size difference is ~14% per tier: medium is 331,544 (HOST) vs 290,120 (SBF), large is 1,321,112 vs 1,156,808
- `SLAB_TIERS` (the mainnet default) aliased to HOST sizes — `discoverMarkets` `getProgramAccounts` `dataSize` filters would **find zero V12.1 slabs on mainnet**
- **Fix**: Added `SLAB_TIERS_V12_1_SBF` export computed from SBF constants. Changed `SLAB_TIERS` to alias SBF sizes. Added both HOST and SBF V12.1 to `ALL_TIERS` for discovery of slabs from any build target.
- `SLAB_TIERS_V12_1` (HOST) preserved unchanged for test builds and backward compatibility

## Test plan
- [x] Discovery tests pass (60/60) — tier count updated
- [x] No new test failures introduced (16 pre-existing failures from HOST bitmapOff + ADL mock issues are separate)
- [ ] Verify SBF tier sizes match deployed mainnet slabs
- [ ] Verify `discoverMarkets` finds V12.1 SBF slabs via dataSize filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated slab tier configurations to reflect new mainnet SBF layout specifications
  * Enhanced market discovery by extending tier coverage to include both SBF and test slab layouts
  * Refined slab size calculations for improved accuracy in market creation and discovery processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->