### PR TITLE
fix(slab): correct HOST bitmapOff double-subtraction in buildLayoutV12_1

### DIFF
--- a/src/solana/slab.ts
+++ b/src/solana/slab.ts
@@ -1247,7 +1247,7 @@ function buildLayoutV12_1(maxAccounts: number, dataLen?: number): SlabLayout {
   const hostSize = computeSlabSize(V12_1_ENGINE_OFF, V12_1_ENGINE_BITMAP_OFF, V12_1_ACCOUNT_SIZE, maxAccounts, 18);
   const isSbf = dataLen !== undefined && dataLen !== hostSize;
   const engineOff = isSbf ? V12_1_SBF_ENGINE_OFF : V12_1_ENGINE_OFF;
-  const bitmapOff = isSbf ? V12_1_SBF_BITMAP_OFF : (V12_1_ENGINE_BITMAP_OFF - V12_1_ENGINE_OFF);
+  const bitmapOff = isSbf ? V12_1_SBF_BITMAP_OFF : V12_1_ENGINE_BITMAP_OFF;
   const accountSize = isSbf ? V12_1_ACCOUNT_SIZE_SBF : V12_1_ACCOUNT_SIZE;
   const bitmapWords = Math.ceil(maxAccounts / 64);
   const bitmapBytes = bitmapWords * 8;


### PR DESCRIPTION
## Summary
- `buildLayoutV12_1` computed HOST `bitmapOff` as `V12_1_ENGINE_BITMAP_OFF - V12_1_ENGINE_OFF` (1016 - 648 = 368)
- But `V12_1_ENGINE_BITMAP_OFF` (1016) is already relative to `engineOff`, consistent with `computeSlabSize` and all other layout builders
- The subtraction double-adjusted, producing 368 instead of 1016
- This caused wrong `accountsOff` for HOST test slabs and **8 failing drift-check tests**
- One-character fix: remove the `- V12_1_ENGINE_OFF` subtraction

## Test plan
- [x] drift-check tests: **46 passed** (was 38 passed + 8 failed — all 8 HOST bitmapOff failures resolved)
- [x] Full suite: 737 passed (8 remaining failures are pre-existing ADL mock issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)