### PR TITLE
harden: deep-freeze PROGRAM_IDS, STAKE_PROGRAM_IDS, and STAKE_IX

### DIFF
--- a/src/config/program-ids.ts
+++ b/src/config/program-ids.ts
@@ -32,6 +32,11 @@ export const PROGRAM_IDS = {
     matcher: "DHP6DtwXP1yJsz8YzfoeigRFPB979gzmumkmCxDLSkUX",
   },
 } as const;
+// Runtime immutability: as const is compile-time only. Deep-freeze prevents
+// supply-chain attacks that could redirect program IDs via mutation.
+Object.freeze(PROGRAM_IDS.devnet);
+Object.freeze(PROGRAM_IDS.mainnet);
+Object.freeze(PROGRAM_IDS);
 
 export type Network = "devnet" | "mainnet";
 

--- a/src/solana/stake.ts
+++ b/src/solana/stake.ts
@@ -19,6 +19,7 @@ export const STAKE_PROGRAM_IDS = {
   devnet: '6aJb1F9CDCVWCNYFwj8aQsVb696YnW6J1FznteHq4Q6k',
   mainnet: 'DC5fovFQD5SZYsetwvEqd4Wi4PFY1Yfnc669VMe6oa7F',
 } as const;
+Object.freeze(STAKE_PROGRAM_IDS);
 
 /**
  * Resolve the stake program ID for the given network.
@@ -95,6 +96,7 @@ export const STAKE_IX = {
   /** PERC-303: Deposit into junior (first-loss) tranche */
   DepositJunior: 16,
 } as const;
+Object.freeze(STAKE_IX);
 
 // ═══════════════════════════════════════════════════════════════
 // PDA Derivation


### PR DESCRIPTION
## Summary
- `as const` is **compile-time only** — it does NOT prevent runtime mutation
- Without `Object.freeze`, a supply-chain attack or prototype pollution could silently redirect program IDs:
  ```js
  (PROGRAM_IDS as any).mainnet.percolator = "attacker-program";
  ```
- This would redirect all user transactions to an attacker-controlled program
- **Fix**: Deep-freeze `PROGRAM_IDS` (both nested network objects + top-level), `STAKE_PROGRAM_IDS`, and `STAKE_IX`
- Follows the precedent of `IX_TAG` which was frozen in PR #135
- Zero code paths mutate these objects — all accesses are read-only

### Objects frozen:
| Object | File | Freeze Type | Threat |
|--------|------|-------------|--------|
| `PROGRAM_IDS` | program-ids.ts | Deep (inner + outer) | Program ID substitution |
| `STAKE_PROGRAM_IDS` | stake.ts | Shallow (flat strings) | Staking redirect |
| `STAKE_IX` | stake.ts | Shallow (flat numbers) | Instruction tag corruption |

## Test plan
- [x] No new test failures (729 passed, same 16 pre-existing)
- [x] Verified: no code path mutates these objects
- [x] Env var overrides (`PROGRAM_ID`, `STAKE_PROGRAM_ID`) still work — they return early before touching frozen objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)