### PR TITLE
harden: deep-freeze PERCOLATOR_ERRORS to prevent error suppression

### DIFF
--- a/src/abi/errors.ts
+++ b/src/abi/errors.ts
@@ -274,6 +274,10 @@ export const PERCOLATOR_ERRORS: Record<number, ErrorInfo> = {
     hint: "ADL rejected — the target position is already closed (size == 0). Re-rank and pick a different target.",
   },
 };
+// Runtime immutability: prevent supply-chain attacks from suppressing
+// error messages (e.g., hiding undercollateralization errors).
+for (const v of Object.values(PERCOLATOR_ERRORS)) Object.freeze(v);
+Object.freeze(PERCOLATOR_ERRORS);
 
 /**
  * Decode a custom program error code to its info.


### PR DESCRIPTION
## Summary
- `PERCOLATOR_ERRORS` is a plain mutable `Record<number, ErrorInfo>` with 66 error entries
- Without `Object.freeze`, a malicious dependency could rewrite error names/hints:
  ```js
  PERCOLATOR_ERRORS[14] = { name: "OK", hint: "Ignore this" };
  ```
- This would suppress `EngineUndercollateralized` errors in keeper logs, masking liquidation failures
- **Fix**: Deep-freeze each inner `ErrorInfo` object and the outer record
- No code path mutates this object — all access is read-only via `decodeError()`, `getErrorName()`, `getErrorHint()`

## Test plan
- [x] Error tests pass (27/27)
- [x] No new test failures (729 passed, same 16 pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)