### PR TITLE
harden: validate slab magic in parseEngine and parseConfig

### DIFF
--- a/src/solana/slab.ts
+++ b/src/solana/slab.ts
@@ -1704,6 +1704,11 @@ export function parseHeader(data: Uint8Array): SlabHeader {
  * @param layoutHint - Pre-detected layout to use; if omitted, detected from data.length.
  */
 export function parseConfig(data: Uint8Array, layoutHint?: SlabLayout | null): MarketConfig {
+  // Validate magic before parsing — prevents silent garbage interpretation of
+  // arbitrary buffers that happen to match a known slab size.
+  if (data.length >= 8 && readU64LE(data, 0) !== MAGIC) {
+    throw new Error(`parseConfig: invalid slab magic (expected PERCOLAT)`);
+  }
   const layout = layoutHint !== undefined ? layoutHint : detectSlabLayout(data.length, data);
   const configOff = layout ? layout.configOffset : V0_HEADER_LEN;
   const configLen = layout ? layout.configLen : V0_CONFIG_LEN;
@@ -1973,6 +1978,11 @@ export function parseParams(data: Uint8Array, layoutHint?: SlabLayout | null): R
  * Parse RiskEngine state (excluding accounts array). Layout-version aware.
  */
 export function parseEngine(data: Uint8Array): EngineState {
+  // Validate magic before parsing — prevents silent garbage interpretation of
+  // arbitrary buffers that happen to match a known slab size.
+  if (data.length >= 8 && readU64LE(data, 0) !== MAGIC) {
+    throw new Error(`parseEngine: invalid slab magic (expected PERCOLAT)`);
+  }
   const layout = detectSlabLayout(data.length, data);
   if (!layout) {
     throw new Error(`Unrecognized slab data length: ${data.length}. Cannot determine layout version.`);


### PR DESCRIPTION
## Summary
- `parseEngine` and `parseConfig` can be called directly without going through `parseHeader` (which validates the PERCOLAT magic bytes)
- `adl.ts` calls both functions directly — `isAdlTriggered`, `rankAdlPositions`
- Without magic validation, a malicious RPC returning arbitrary bytes of a known slab size would be silently parsed, producing garbage vault balances, PnL, oracle addresses, and config values
- **Fix**: Added PERCOLAT magic byte check (`readU64LE(data, 0) !== MAGIC`) at the top of both functions
- Cheap (one u64 read), zero false positives — valid slab data always starts with PERCOLAT magic

## Test plan
- [x] No new test failures (729 passed, same 16 pre-existing)
- [ ] Verify non-slab data of matching size throws with "invalid slab magic"

🤖 Generated with [Claude Code](https://claude.com/claude-code)