### PR TITLE
harden: add optional owner validation to fetchSlab

### DIFF
--- a/src/solana/slab.ts
+++ b/src/solana/slab.ts
@@ -1599,11 +1599,18 @@ export interface Account {
 
 export async function fetchSlab(
   connection: Connection,
-  slabPubkey: PublicKey
+  slabPubkey: PublicKey,
+  expectedOwner?: PublicKey,
 ): Promise<Uint8Array> {
   const info = await connection.getAccountInfo(slabPubkey);
   if (!info) {
     throw new Error(`Slab account not found: ${slabPubkey.toBase58()}`);
+  }
+  if (expectedOwner && !info.owner.equals(expectedOwner)) {
+    throw new Error(
+      `fetchSlab: account ${slabPubkey.toBase58()} owner mismatch — ` +
+      `expected ${expectedOwner.toBase58()}, got ${info.owner.toBase58()}`,
+    );
   }
   return new Uint8Array(info.data);
 }


### PR DESCRIPTION
## Summary
- `fetchSlab` returned raw account data without checking `info.owner` against the expected Percolator program ID
- A malicious or misconfigured RPC could return data from an arbitrary account — if it has the correct magic bytes and matches a known slab size, the SDK would parse it as a valid slab with attacker-controlled engine state
- `getMarketsByAddress` already has owner validation (PR #128), but `fetchSlab` (used directly by keepers and ADL bots) did not
- **Fix**: Added optional `expectedOwner?: PublicKey` parameter. When provided, validates `info.owner.equals(expectedOwner)` before returning. Fully backward compatible.

## Test plan
- [x] No new test failures (729 passed, same 16 pre-existing)
- [ ] Verify `fetchSlab(conn, key, wrongOwner)` throws with descriptive owner mismatch error
- [ ] Verify `fetchSlab(conn, key)` (no owner) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added optional ownership verification for enhanced data integrity. When enabled, the system now validates ownership and provides explicit error messages including expected versus actual ownership values, helping users quickly diagnose and resolve authentication issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->