### PR TITLE
harden: validate all AdlApiResult top-level fields before cast

### DIFF
--- a/src/solana/adl.ts
+++ b/src/solana/adl.ts
@@ -585,6 +585,24 @@ export async function fetchAdlRankings(
   if (!Array.isArray(obj.rankings)) {
     throw new Error("fetchAdlRankings: API response missing rankings array");
   }
+  // Validate top-level fields — a schema mismatch from a compromised or
+  // updated API should throw, not silently produce undefined fields.
+  if (typeof obj.adlNeeded !== "boolean") {
+    throw new Error(`fetchAdlRankings: adlNeeded must be boolean, got ${typeof obj.adlNeeded}`);
+  }
+  if (typeof obj.capExceeded !== "boolean") {
+    throw new Error(`fetchAdlRankings: capExceeded must be boolean, got ${typeof obj.capExceeded}`);
+  }
+  if (typeof obj.slabAddress !== "string") {
+    throw new Error(`fetchAdlRankings: slabAddress must be string, got ${typeof obj.slabAddress}`);
+  }
+  if (typeof obj.pnlPosTot !== "string") {
+    throw new Error(`fetchAdlRankings: pnlPosTot must be string, got ${typeof obj.pnlPosTot}`);
+  }
+  if (typeof obj.maxPnlCap !== "string") {
+    throw new Error(`fetchAdlRankings: maxPnlCap must be string, got ${typeof obj.maxPnlCap}`);
+  }
+
   for (const entry of obj.rankings) {
     if (typeof entry !== "object" || entry === null) {
       throw new Error("fetchAdlRankings: invalid ranking entry (not an object)");


### PR DESCRIPTION
## Summary
- `fetchAdlRankings` validated `rankings` array and `idx` fields but used `as AdlApiResult` cast without checking top-level fields
- A compromised or updated API returning `adlNeeded: "yes"` (string instead of boolean) or `pnlPosTot: 12345` (number instead of string) would silently pass through
- Downstream code like `BigInt(result.pnlPosTot)` would throw a confusing TypeError far from the actual problem
- **Fix**: Added `typeof` checks for the 5 most critical fields: `adlNeeded` (boolean), `capExceeded` (boolean), `slabAddress` (string), `pnlPosTot` (string), `maxPnlCap` (string)
- Throws immediately with a descriptive error identifying which field has the wrong type

## Test plan
- [x] ADL tests pass (26/26)
- [x] No new test failures (729 passed, same 16 pre-existing)
- [ ] Verify malformed API response with wrong types throws descriptive error

🤖 Generated with [Claude Code](https://claude.com/claude-code)