### PR TITLE
harden: freeze PYTH_SOLANA_FEEDS and all SLAB_TIERS_* exports

### DIFF
--- a/src/oracle/price-router.ts
+++ b/src/oracle/price-router.ts
@@ -191,6 +191,9 @@ export const PYTH_SOLANA_FEEDS: Record<string, { symbol: string; mint: string }>
   // IOT
   "8bdd20f0c68bf7370a19389bbb3d17c1db7956c38efa08b2f3dd0e5db9b8c1ef": { symbol: "IOT", mint: "iotEVVZLEywoTn1QdwNPddxPWszn3zFhEot3MfL9fns" },
 };
+// Runtime immutability: prevent oracle feed poisoning via mutation.
+for (const v of Object.values(PYTH_SOLANA_FEEDS)) Object.freeze(v);
+Object.freeze(PYTH_SOLANA_FEEDS);
 
 // Reverse lookup: mint → feed ID
 const MINT_TO_PYTH_FEED = new Map<string, { feedId: string; symbol: string }>();

--- a/src/solana/slab.ts
+++ b/src/solana/slab.ts
@@ -691,6 +691,8 @@ for (const [label, n] of [["Micro", 64], ["Small", 256], ["Medium", 1024], ["Lar
   const size = computeSlabSize(V1M_ENGINE_OFF, V1M_ENGINE_BITMAP_OFF, V1M_ACCOUNT_SIZE, n, 18);
   SLAB_TIERS_V1M[label.toLowerCase()] = { maxAccounts: n, dataSize: size, label, description: `${n} slots (V1M mainnet)` };
 }
+for (const v of Object.values(SLAB_TIERS_V1M)) Object.freeze(v);
+Object.freeze(SLAB_TIERS_V1M);
 
 /**
  * V1M2 slab tier sizes — mainnet program rebuilt from main@4861c56 with 312-byte accounts.
@@ -703,6 +705,8 @@ for (const [label, n] of [["Micro", 64], ["Small", 256], ["Medium", 1024], ["Lar
   const size = computeSlabSize(V1M2_ENGINE_OFF, V1M2_ENGINE_BITMAP_OFF, V1M2_ACCOUNT_SIZE, n, 18);
   SLAB_TIERS_V1M2[label.toLowerCase()] = { maxAccounts: n, dataSize: size, label, description: `${n} slots (V1M2 mainnet upgraded)` };
 }
+for (const v of Object.values(SLAB_TIERS_V1M2)) Object.freeze(v);
+Object.freeze(SLAB_TIERS_V1M2);
 
 /**
  * V_ADL slab tier sizes — PERC-8270/8271 ADL-upgraded program.
@@ -715,6 +719,8 @@ for (const [label, n] of [["Micro", 64], ["Small", 256], ["Medium", 1024], ["Lar
   const size = computeSlabSize(V_ADL_ENGINE_OFF, V_ADL_ENGINE_BITMAP_OFF, V_ADL_ACCOUNT_SIZE, n, 18);
   SLAB_TIERS_V_ADL[label.toLowerCase()] = { maxAccounts: n, dataSize: size, label, description: `${n} slots (V_ADL PERC-8270)` };
 }
+for (const v of Object.values(SLAB_TIERS_V_ADL)) Object.freeze(v);
+Object.freeze(SLAB_TIERS_V_ADL);
 
 /**
  * Build a complete SlabLayout descriptor for V0 or V1 (including V1-legacy) slabs.
@@ -1159,6 +1165,8 @@ for (const [label, n] of [["Micro", 64], ["Small", 256], ["Medium", 1024], ["Lar
   const size = computeSlabSize(V_SETDEXPOOL_ENGINE_OFF, V_ADL_ENGINE_BITMAP_OFF, V_ADL_ACCOUNT_SIZE, n, 18);
   SLAB_TIERS_V_SETDEXPOOL[label.toLowerCase()] = { maxAccounts: n, dataSize: size, label, description: `${n} slots (V_SETDEXPOOL PERC-SetDexPool)` };
 }
+for (const v of Object.values(SLAB_TIERS_V_SETDEXPOOL)) Object.freeze(v);
+Object.freeze(SLAB_TIERS_V_SETDEXPOOL);
 
 /**
  * V12_1 slab tier sizes — percolator-core v12.1 merge.
@@ -1170,6 +1178,8 @@ for (const [label, n] of [["Micro", 64], ["Small", 256], ["Medium", 1024], ["Lar
   const size = computeSlabSize(V12_1_ENGINE_OFF, V12_1_ENGINE_BITMAP_OFF, V12_1_ACCOUNT_SIZE, n, 18);
   SLAB_TIERS_V12_1[label.toLowerCase()] = { maxAccounts: n, dataSize: size, label, description: `${n} slots (v12.1)` };
 }
+for (const v of Object.values(SLAB_TIERS_V12_1)) Object.freeze(v);
+Object.freeze(SLAB_TIERS_V12_1);
 
 /**
  * Build a SlabLayout for V_SETDEXPOOL slabs (PERC-SetDexPool security fix).


### PR DESCRIPTION
## Summary
- Exported config objects (`PYTH_SOLANA_FEEDS`, `SLAB_TIERS_V1M`, `SLAB_TIERS_V1M2`, `SLAB_TIERS_V_ADL`, `SLAB_TIERS_V_SETDEXPOOL`, `SLAB_TIERS_V12_1`) were plain mutable Records
- A compromised dependency could mutate them to poison oracle feeds or corrupt layout detection
- Deep-freezes each object and its inner entries after population loops complete
- Follows the precedent of `IX_TAG` (PR #135) and `PROGRAM_IDS` (PR #189)

## Test plan
- [x] No new test failures (729 passed, same 16 pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)