### PR TITLE
harden: add package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 *.tsbuildinfo
+package-lock.json
 .env
 .env.*
 


### PR DESCRIPTION
## Summary
- A stale `package-lock.json` (version `0.5.1`) existed alongside the authoritative `pnpm-lock.yaml` (version `1.0.0-beta.13`)
- `npm install` would resolve a completely different dependency tree than `pnpm install`
- Dual divergent lock files are a supply-chain confusion vector
- Added `package-lock.json` to `.gitignore` to prevent accidental commits

## Test plan
- [x] No test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)