### PR TITLE
harden: add magic validation and buffer bounds to parseEngine/parseConfig

### DIFF
--- a/src/solana/slab.ts
+++ b/src/solana/slab.ts
@@ -1704,6 +1704,10 @@ export function parseHeader(data: Uint8Array): SlabHeader {
  * @param layoutHint - Pre-detected layout to use; if omitted, detected from data.length.
  */
 export function parseConfig(data: Uint8Array, layoutHint?: SlabLayout | null): MarketConfig {
+  // Validate magic — prevents silent garbage parsing of non-Percolator buffers.
+  if (data.length >= 8 && readU64LE(data, 0) !== MAGIC) {
+    throw new Error(`parseConfig: invalid slab magic (expected PERCOLAT)`);
+  }
   const layout = layoutHint !== undefined ? layoutHint : detectSlabLayout(data.length, data);
   const configOff = layout ? layout.configOffset : V0_HEADER_LEN;
   const configLen = layout ? layout.configLen : V0_CONFIG_LEN;
@@ -1973,12 +1977,27 @@ export function parseParams(data: Uint8Array, layoutHint?: SlabLayout | null): R
  * Parse RiskEngine state (excluding accounts array). Layout-version aware.
  */
 export function parseEngine(data: Uint8Array): EngineState {
+  // Validate magic — prevents silent garbage parsing of arbitrary buffers
+  // that happen to match a known slab size. adl.ts calls parseEngine directly
+  // without going through parseHeader which normally validates this.
+  if (data.length >= 8 && readU64LE(data, 0) !== MAGIC) {
+    throw new Error(`parseEngine: invalid slab magic (expected PERCOLAT)`);
+  }
   const layout = detectSlabLayout(data.length, data);
   if (!layout) {
     throw new Error(`Unrecognized slab data length: ${data.length}. Cannot determine layout version.`);
   }
 
   const base = layout.engineOff;
+  // Bounds check: ensure buffer covers through the engine section.
+  // Catches truncated RPC responses before they produce garbage BigInts
+  // or cryptic DataView RangeErrors.
+  if (data.length < layout.accountsOff) {
+    throw new Error(
+      `parseEngine: slab data too short — got ${data.length} bytes, ` +
+      `need at least ${layout.accountsOff} (engineOff=${base})`,
+    );
+  }
 
   return {
     vault: readU128LE(data, base),


### PR DESCRIPTION
## Summary
- `parseEngine` and `parseConfig` can be called directly from `adl.ts` without going through `parseHeader` (which validates PERCOLAT magic)
- A malicious RPC returning arbitrary bytes matching a known slab size would be silently parsed into garbage engine state (vault balances, PnL, oracle data) or config (collateral mint, oracle authority)
- `parseEngine` also had zero buffer bounds checking — truncated RPC data would produce either garbage BigInts (silent wrong values) or cryptic `DataView RangeError` with no context

**Additions:**
- PERCOLAT magic check at the top of both `parseEngine` and `parseConfig` — one `readU64LE` comparison, zero overhead for valid slabs
- Buffer bounds check in `parseEngine`: `data.length < layout.accountsOff` ensures the buffer covers the entire engine section before any field reads

## Test plan
- [x] No new test failures (729 passed, same 16 pre-existing)
- [x] All test mock slabs include PERCOLAT magic at offset 0 — zero false positives
- [x] All test buffers are full-tier-sized — bounds check never trips on valid data

🤖 Generated with [Claude Code](https://claude.com/claude-code)