### PR TITLE
harden: add instruction data length assertions to critical encoders

### DIFF
--- a/src/abi/instructions.ts
+++ b/src/abi/instructions.ts
@@ -353,12 +353,14 @@ export interface TradeNoCpiArgs {
 }
 
 export function encodeTradeNoCpi(args: TradeNoCpiArgs): Uint8Array {
-  return concatBytes(
+  const data = concatBytes(
     encU8(IX_TAG.TradeNoCpi),
     encU16(args.lpIdx),
     encU16(args.userIdx),
     encI128(args.size),
   );
+  if (data.length !== 21) throw new Error(`encodeTradeNoCpi: expected 21 bytes, got ${data.length}`);
+  return data;
 }
 
 /**
@@ -407,12 +409,14 @@ export interface TradeCpiArgs {
 }
 
 export function encodeTradeCpi(args: TradeCpiArgs): Uint8Array {
-  return concatBytes(
+  const data = concatBytes(
     encU8(IX_TAG.TradeCpi),
     encU16(args.lpIdx),
     encU16(args.userIdx),
     encI128(args.size),
   );
+  if (data.length !== 21) throw new Error(`encodeTradeCpi: expected 21 bytes, got ${data.length}`);
+  return data;
 }
 
 /**
@@ -431,13 +435,15 @@ export interface TradeCpiV2Args {
 }
 
 export function encodeTradeCpiV2(args: TradeCpiV2Args): Uint8Array {
-  return concatBytes(
+  const data = concatBytes(
     encU8(IX_TAG.TradeCpiV2),
     encU16(args.lpIdx),
     encU16(args.userIdx),
     encI128(args.size),
     encU8(args.bump),
   );
+  if (data.length !== 22) throw new Error(`encodeTradeCpiV2: expected 22 bytes, got ${data.length}`);
+  return data;
 }
 
 /**
@@ -495,7 +501,7 @@ export interface UpdateConfigArgs {
 }
 
 export function encodeUpdateConfig(args: UpdateConfigArgs): Uint8Array {
-  return concatBytes(
+  const data = concatBytes(
     encU8(IX_TAG.UpdateConfig),
     encU64(args.fundingHorizonSlots),
     encU64(args.fundingKBps),
@@ -511,6 +517,9 @@ export function encodeUpdateConfig(args: UpdateConfigArgs): Uint8Array {
     encU128(args.threshMax),
     encU128(args.threshMinStep),
   );
+  // tag(1) + 6×u64(48) + 2×i64(16) + 5×u128(80) = 145
+  if (data.length !== 145) throw new Error(`encodeUpdateConfig: expected 145 bytes, got ${data.length}`);
+  return data;
 }
 
 /**
@@ -1016,7 +1025,9 @@ export interface ExecuteAdlArgs {
 }
 
 export function encodeExecuteAdl(args: ExecuteAdlArgs): Uint8Array {
-  return concatBytes(encU8(IX_TAG.ExecuteAdl), encU16(args.targetIdx));
+  const data = concatBytes(encU8(IX_TAG.ExecuteAdl), encU16(args.targetIdx));
+  if (data.length !== 3) throw new Error(`encodeExecuteAdl: expected 3 bytes, got ${data.length}`);
+  return data;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Only `encodeInitMarket` had a post-encode length assertion (352 bytes). All other encoders returned `concatBytes(...)` with no size verification.
- A developer adding/removing a field from `concatBytes` without updating the layout could silently produce wrong-length instruction data, causing the on-chain decoder to misparse or panic.
- Added assertions to 5 safety-critical encoders:

| Encoder | Expected | Fields | Why Critical |
|---------|----------|--------|-------------|
| `encodeTradeCpi` | 21 bytes | 4 | User funds — trade execution |
| `encodeTradeCpiV2` | 22 bytes | 5 | User funds — trade execution |
| `encodeTradeNoCpi` | 21 bytes | 4 | User funds — trade execution |
| `encodeExecuteAdl` | 3 bytes | 2 | Auto-deleveraging positions |
| `encodeUpdateConfig` | 145 bytes | 14 | Market config — highest layout-error risk |

- All `enc*` helpers return fixed-size arrays — assertions can never false-positive on valid inputs
- Follows the `encodeInitMarket` pattern already established at line 260

## Test plan
- [x] All 44 instruction tests pass
- [x] No new test failures (729 passed, same 16 pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)