### PR TITLE
harden: switch to equal jitter for retry backoff decorrelation

### DIFF
--- a/src/solana/discovery.ts
+++ b/src/solana/discovery.ts
@@ -553,9 +553,10 @@ function isRateLimitError(err: unknown): boolean {
   );
 }
 
-/** Add up to 25% random jitter to avoid thundering-herd on retry. */
+/** Equal jitter: spread across [delay/2, delay] for fleet decorrelation. */
 function withJitter(delayMs: number): number {
-  return delayMs + Math.floor(Math.random() * delayMs * 0.25);
+  const half = Math.floor(delayMs / 2);
+  return half + Math.floor(Math.random() * (delayMs - half + 1));
 }
 
 /**

--- a/src/solana/rpc-pool.ts
+++ b/src/solana/rpc-pool.ts
@@ -305,8 +305,11 @@ function computeDelay(attempt: number, config: ResolvedRetryConfig): number {
     config.baseDelayMs * Math.pow(2, attempt),
     config.maxDelayMs,
   );
-  const jitter = Math.floor(Math.random() * raw * config.jitterFactor);
-  return raw + jitter;
+  // Equal jitter: spread retries across [raw/2, raw] instead of [raw, raw*1.25].
+  // Prevents thundering herd after outages while maintaining a meaningful backoff floor.
+  if (config.jitterFactor === 0) return raw; // deterministic path for tests
+  const half = Math.floor(raw / 2);
+  return half + Math.floor(Math.random() * (raw - half + 1));
 }
 
 function rejectAfter<T>(ms: number, message: string): { promise: Promise<T>; cancel: () => void } {

--- a/test/rpc-pool.test.ts
+++ b/test/rpc-pool.test.ts
@@ -103,11 +103,11 @@ describe("_internal helpers", () => {
         baseDelayMs: 1000,
         jitterFactor: 0.25,
       })!;
-      // Run 100 times — delay should be in [1000, 1250] for attempt 0
+      // Run 100 times — equal jitter: delay should be in [500, 1000] for attempt 0
       for (let i = 0; i < 100; i++) {
         const delay = _internal.computeDelay(0, config);
-        expect(delay).toBeGreaterThanOrEqual(1000);
-        expect(delay).toBeLessThanOrEqual(1250);
+        expect(delay).toBeGreaterThanOrEqual(500);
+        expect(delay).toBeLessThanOrEqual(1000);
       }
     });
   });


### PR DESCRIPTION
## Summary
- Additive-only jitter produced delays in `[raw, raw*1.25]` — only 25% spread
- In a keeper fleet, all instances retry within the same narrow band after an outage → thundering herd
- **Fix**: Equal jitter `[raw/2, raw]` — 2x the spread with a meaningful minimum backoff floor
- `jitterFactor: 0` still produces deterministic delays for tests (backward compat)
- Also applied to `discovery.ts` `withJitter` helper (same additive-only pattern)

## Test plan
- [x] rpc-pool tests pass (57/57) — updated range assertion from [1000,1250] to [500,1000]
- [x] No new test failures (729 passed, same 16 pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)