### PR TITLE
harden: add layout invariant validation to detectSlabLayout

### DIFF
--- a/src/solana/slab.ts
+++ b/src/solana/slab.ts
@@ -1324,16 +1324,30 @@ function buildLayoutV12_1(maxAccounts: number, dataLen?: number): SlabLayout {
  * @param dataLen - The slab account data length in bytes
  * @param data    - Optional raw slab data for version-field disambiguation
  */
+/** Validate layout invariants before returning from detectSlabLayout. */
+function validateLayout(l: SlabLayout): SlabLayout {
+  if (l.accountsOff <= l.engineOff) {
+    throw new Error(`Layout invariant: accountsOff (${l.accountsOff}) must be > engineOff (${l.engineOff})`);
+  }
+  if (l.engineBitmapOff <= l.engineParamsOff) {
+    throw new Error(`Layout invariant: bitmapOff (${l.engineBitmapOff}) must be > paramsOff (${l.engineParamsOff})`);
+  }
+  if (l.maxAccounts < 1 || l.maxAccounts > 65536) {
+    throw new Error(`Layout invariant: maxAccounts (${l.maxAccounts}) out of range [1, 65536]`);
+  }
+  return l;
+}
+
 export function detectSlabLayout(dataLen: number, data?: Uint8Array): SlabLayout | null {
   // Check V12_1 sizes first (percolator-core v12.1, ACCOUNT_SIZE=320, BITMAP_OFF=1016).
   // Largest account size — no size collision with any earlier layout.
   const v121n = V12_1_SIZES.get(dataLen);
-  if (v121n !== undefined) return buildLayoutV12_1(v121n, dataLen);
+  if (v121n !== undefined) return validateLayout(buildLayoutV12_1(v121n, dataLen));
 
   // Check V_SETDEXPOOL sizes (PERC-SetDexPool, ENGINE_OFF=648, CONFIG_LEN=544).
   // These are the pre-v12.1 newest slabs — largest ENGINE_OFF so no size collision with V_ADL (624).
   const vsdpn = V_SETDEXPOOL_SIZES.get(dataLen);
-  if (vsdpn !== undefined) return buildLayoutVSetDexPool(vsdpn);
+  if (vsdpn !== undefined) return validateLayout(buildLayoutVSetDexPool(vsdpn));
 
   // Check V1M2 sizes. After fixing bitmapOff to 1008 for both V1M2 and V_ADL,
   // their sizes no longer collide (engineOff differs: 616 vs 624), so size-based detection
@@ -1341,20 +1355,20 @@ export function detectSlabLayout(dataLen: number, data?: Uint8Array): SlabLayout
   //   V1M2 medium (1024 accts): computeSlabSize(616, 1008, 312, 1024, 18) = 323312
   //   V_ADL medium (1024 accts): computeSlabSize(624, 1008, 312, 1024, 18) = 323320
   const v1m2n = V1M2_SIZES.get(dataLen);
-  if (v1m2n !== undefined) return buildLayoutV1M2(v1m2n);
+  if (v1m2n !== undefined) return validateLayout(buildLayoutV1M2(v1m2n));
 
   // Check V_ADL sizes (PERC-8270/8271, ENGINE_OFF=624, BITMAP_OFF=1008, ACCOUNT_SIZE=312).
   const vadln = V_ADL_SIZES.get(dataLen);
-  if (vadln !== undefined) return buildLayoutVADL(vadln);
+  if (vadln !== undefined) return validateLayout(buildLayoutVADL(vadln));
 
   // Check V1M sizes (mainnet-deployed V1 program, ESa89R5).
   // Must be checked before V1_LEGACY because V1M sizes are unique and don't overlap.
   const v1mn = V1M_SIZES.get(dataLen);
-  if (v1mn !== undefined) return buildLayoutV1M(v1mn);
+  if (v1mn !== undefined) return validateLayout(buildLayoutV1M(v1mn));
 
   // Check V0 sizes (deployed devnet V0 program)
   const v0n = V0_SIZES.get(dataLen);
-  if (v0n !== undefined) return buildLayout(0, v0n);
+  if (v0n !== undefined) return validateLayout(buildLayout(0, v0n));
 
   // Check V1D sizes (actually deployed V1 program — ENGINE_OFF=424, correct struct layout).
   // V2 slabs produce identical sizes (postBitmap=18 for V2 == postBitmap=2 for V1D).
@@ -1363,27 +1377,27 @@ export function detectSlabLayout(dataLen: number, data?: Uint8Array): SlabLayout
   if (v1dn !== undefined) {
     if (data && data.length >= 12) {
       const version = readU32LE(data, 8);
-      if (version === 2) return buildLayoutV2(v1dn);
+      if (version === 2) return validateLayout(buildLayoutV2(v1dn));
     }
-    return buildLayoutV1D(v1dn, 2);
+    return validateLayout(buildLayoutV1D(v1dn, 2));
   }
 
   // Check V1D legacy sizes (postBitmap=18 on-chain slabs created before GH#1234 fix).
   // e.g. slab 6ZytbpV4 (TEST/USD, top active market) = 65104 bytes, uses postBitmap=18.
   // PR #1236 broke these by only registering the postBitmap=2 size; GH#1237 restores support.
   const v1dln = V1D_SIZES_LEGACY.get(dataLen);
-  if (v1dln !== undefined) return buildLayoutV1D(v1dln, 18);
+  if (v1dln !== undefined) return validateLayout(buildLayoutV1D(v1dln, 18));
 
   // Check V1 sizes (future V1 program — ENGINE_OFF=600, PERC-1094 corrected)
   const v1n = V1_SIZES.get(dataLen);
-  if (v1n !== undefined) return buildLayout(1, v1n);
+  if (v1n !== undefined) return validateLayout(buildLayout(1, v1n));
 
   // Check legacy V1 sizes (pre-PERC-1094 SDK used ENGINE_OFF=640; orphaned on devnet)
   const v1ln = V1_SIZES_LEGACY.get(dataLen);
   // PERC-1095 follow-up: must pass V1_ENGINE_OFF_LEGACY (640) so the returned SlabLayout
   // has .engineOff=640 — without the override buildLayout would use V1_ENGINE_OFF=600,
   // causing all engine reads on legacy slabs to land at the wrong byte offset.
-  if (v1ln !== undefined) return buildLayout(1, v1ln, V1_ENGINE_OFF_LEGACY);
+  if (v1ln !== undefined) return validateLayout(buildLayout(1, v1ln, V1_ENGINE_OFF_LEGACY));
 
   return null;
 }


### PR DESCRIPTION
## Summary
- `detectSlabLayout` returns layouts from 10+ `buildLayout*()` functions with no post-construction validation
- Past layout constant errors (V1M bitmap 726→720, V_ADL bitmap 1006→1008, V12.1 HOST bitmapOff double-subtraction) were only caught by failing tests downstream — not at detection time
- **Fix**: `validateLayout` helper checks 3 structural invariants before returning:
  1. `accountsOff > engineOff` — accounts array lives after engine header
  2. `engineBitmapOff > engineParamsOff` — bitmap follows params in engine struct
  3. `maxAccounts ∈ [1, 65536]` — sane tier bounds
- Wraps all 11 return paths in `detectSlabLayout`
- Catches layout constant transcription errors immediately instead of producing garbled data downstream

## Test plan
- [x] No new test failures (729 passed, same 16 pre-existing)
- [x] All 10+ layout variants pass all 3 invariants (verified by agent analysis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)