### PR TITLE
docs(readme): fix devnet matcher address (table was internally inconsistent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ const markets = await discoverMarkets(connection);
 | Stake | Mainnet | `DC5fovFQD5SZYsetwvEqd4Wi4PFY1Yfnc669VMe6oa7F` |
 | NFT | Mainnet | `FqhKJT9gtScjrmfUuRMjeg7cXNpif1fqsy5Jh65tJmTS` |
 | Percolator | Devnet | `FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD` |
-| Matcher | Devnet | `GTRgyTDfrMvBubALAqtHuQwT8tbGyXid7svXZKtWfC9k` |
+| Matcher | Devnet | `4HcGCsyjAqnFua5ccuXyt8KRRQzKFbGTJkVChpS7Yfzy` |
 
 > Use `PROGRAM_ID` / `MATCHER_PROGRAM_ID` env vars to override for local test validators.
 


### PR DESCRIPTION
## what

the "Program Addresses" table at line 446-453 lists devnet matcher as `GTRgyTDfrMvBubALAqtHuQwT8tbGyXid7svXZKtWfC9k`. that program has had no devnet transactions since 2026-03-30. the active devnet matcher is `4HcGCsyjAqnFua5ccuXyt8KRRQzKFbGTJkVChpS7Yfzy`, which the same README already documents at line 747 ("Devnet Program Addresses" table).

same README, same field, two different values across two tables.

## why

verified via `getSignaturesForAddress` against `api.devnet.solana.com` on 2026-05-05:

| address | source line | latest tx | status |
|---|---|---|---|
| `GTRgyTDfr...` | line 453 (Program Addresses) | 2026-03-30 12:04 UTC | dormant ~36 days |
| `4HcGCsyj...` | line 747 (Devnet Program Addresses) | 2026-05-04 04:39 UTC | active |

both are real, deployed, non-malicious programs (both owned by `BPFLoaderUpgradeable`). the `4HcGCsyj...` address is canonical, it matches what `dcccrypto/percolator-launch/README.md` line 380 also documents.

a developer setting up an SDK integration against devnet using the table at the top of the README hits a dormant program.

## changes

- `README.md` line 453: change `GTRgyTDfrMvBubALAqtHuQwT8tbGyXid7svXZKtWfC9k` to `4HcGCsyjAqnFua5ccuXyt8KRRQzKFbGTJkVChpS7Yfzy`.
- no change to line 747; that table already had the correct value.

## test plan

- [ ] no code changes
- [ ] `4HcGCsyj...` resolves on devnet (verified via RPC)
- [ ] value now matches the second table at line 747 in this same README
- [ ] value matches `percolator-launch/README.md` line 380
