### PR TITLE
audit: SDK wire-format bundle — ResolveMarket mode byte (v2.1.0-beta.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolatorct/sdk",
-  "version": "2.0.9",
+  "version": "2.1.0-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "engines": {

--- a/src/abi/instructions.ts
+++ b/src/abi/instructions.ts
@@ -778,12 +778,36 @@ export function encodeSetOraclePriceCap(args: SetOraclePriceCapArgs): Uint8Array
 }
 
 /**
- * ResolveMarket instruction data (1 byte)
- * Resolves a binary/premarket - sets RESOLVED flag, positions force-closed via crank.
- * Requires admin oracle price (authority_price_e6) to be set first.
+ * ResolveMarket explicit-mode selector. Spec §9.8 distinguishes two
+ * settlement arms:
+ *
+ *   `Ordinary`   = 0 — live oracle accrual (the common path; oracle is
+ *                       healthy or about to be).
+ *   `Degenerate` = 1 — stale-matured fallback at engine.last_oracle_price
+ *                       with funding_rate = 0 (caller has confirmed the
+ *                       oracle is dead beyond `permissionless_resolve_stale_slots`).
  */
-export function encodeResolveMarket(): Uint8Array {
-  return encU8(IX_TAG.ResolveMarket);
+export const RESOLVE_MODE = {
+  Ordinary: 0,
+  Degenerate: 1,
+} as const;
+export type ResolveMode = (typeof RESOLVE_MODE)[keyof typeof RESOLVE_MODE];
+
+/**
+ * ResolveMarket instruction data (2 bytes: tag + mode).
+ *
+ * Resolves a binary/premarket. The post-audit wrapper strict-parses the
+ * `mode` byte; pre-audit deployments accepted either a 1-byte payload
+ * (legacy unwrap_or(0)) or 2 bytes. Always emits 2 bytes so this builder
+ * keeps working across the wire-format strictening planned for the
+ * matching wrapper bundle.
+ *
+ * `mode` defaults to `Ordinary` (the common path) so existing monorepo
+ * callsites stay source-compatible. Callers explicitly recovering from a
+ * dead oracle pass `RESOLVE_MODE.Degenerate`.
+ */
+export function encodeResolveMarket(mode: ResolveMode = RESOLVE_MODE.Ordinary): Uint8Array {
+  return concatBytes(encU8(IX_TAG.ResolveMarket), encU8(mode));
 }
 
 /**

--- a/test/instructions.test.ts
+++ b/test/instructions.test.ts
@@ -193,8 +193,16 @@ describe("instruction encoders", () => {
     expect(encodeCloseSlab()[0]).toBe(IX_TAG.CloseSlab);
   });
 
-  it("encodeResolveMarket produces 1 byte", () => {
-    expect(encodeResolveMarket()[0]).toBe(IX_TAG.ResolveMarket);
+  it("encodeResolveMarket produces 2 bytes (tag + mode)", () => {
+    const ordinary = encodeResolveMarket();
+    expect(ordinary.length).toBe(2);
+    expect(ordinary[0]).toBe(IX_TAG.ResolveMarket);
+    expect(ordinary[1]).toBe(0); // RESOLVE_MODE.Ordinary default
+
+    const degenerate = encodeResolveMarket(1);
+    expect(degenerate.length).toBe(2);
+    expect(degenerate[0]).toBe(IX_TAG.ResolveMarket);
+    expect(degenerate[1]).toBe(1); // RESOLVE_MODE.Degenerate
   });
 
   it("encodeWithdrawInsurance produces 1 byte", () => {


### PR DESCRIPTION
## Summary

Bundle 3 of the wrapper-engine deep-audit Phase 2 execution. Pairs with engine PR #89 (`dcccrypto/percolator`) and the upcoming wrapper bundle 2 PR (`dcccrypto/percolator-prog`).

This SDK release ships one beta cycle ahead of the wrapper Bundle 2 strict-parse rollout, so consumer packages (keeper, indexer, api, admin) have time to upgrade their pin and verify before the wrapper switches.

## Change

`encodeResolveMarket` now emits 2 bytes (tag + mode) instead of 1.

```ts
// Before
encodeResolveMarket()  // 1 byte: [tag(19)]

// After
encodeResolveMarket()                          // 2 bytes: [tag, 0=Ordinary]
encodeResolveMarket(RESOLVE_MODE.Degenerate)   // 2 bytes: [tag, 1=Degenerate]
```

The `mode` parameter defaults to `RESOLVE_MODE.Ordinary` so all existing monorepo callsites stay source-compatible.

New exports:
- `RESOLVE_MODE`: `{ Ordinary: 0, Degenerate: 1 }` const-as-enum
- `ResolveMode`: type alias `0 | 1`

## Wire-format compatibility timeline

| Phase | Wrapper accepts | SDK emits |
|-------|-----------------|-----------|
| Pre-audit (deployed today) | 1-byte (legacy) OR 2-byte (defaults missing byte to 0) | 1 byte |
| **This SDK (v2.1.0-beta.0)** | unchanged on the wrapper side | 2 bytes |
| Wrapper Bundle 2 (post-merge) | 2-byte (strict; rejects missing-byte payload) | 2 bytes |

The 2-byte builder is forward+backward compatible with both wrapper variants. No deployed client breaks at SDK ship; the strict-parse switchover happens in the wrapper PR after this SDK has had one beta cycle for adoption.

## Verification

- `npm test`: **792/823 tests pass, 0 failed, 31 skipped**.
- `test/instructions.test.ts > encodeResolveMarket produces 2 bytes (tag + mode)`: validates both Ordinary (default) and Degenerate variants.
- `test/parity/v12.19-encoder-bytes.parity.test.ts`: passes — byte-level encoding matches the wrapper's accept envelope.
- `test/parity-fixtures.test.ts`: passes — tag mappings unchanged.

## Out of scope (will ship in subsequent SDK versions)

The original Bundle 3 plan also included tag 14 / 23 / 46 builder updates. Those depend on Bundle 2's wrapper changes (tag 23 account-list reshape, tag 46 oracle account, tag 14 tvl_insurance_cap_mult plumbing). Holding them for a follow-up SDK release after wrapper Bundle 2 is open so the SDK changes are not ahead of the on-chain accept envelope.

## Cascade follow-up

Consumer packages need to bump their `@percolatorct/sdk` dependency to `^2.1.0-beta.0` and verify their tag 19 callers pass `RESOLVE_MODE.Degenerate` for stale-recovery paths (default `Ordinary` is correct for live-oracle paths).

- [ ] `dcccrypto/percolator-keeper`
- [ ] `dcccrypto/percolator-api`
- [ ] `dcccrypto/percolator-indexer`
- [ ] admin tooling

🤖 Generated with [Claude Code](https://claude.com/claude-code)