### PR TITLE
fix(slab): remove phantom funding fields from V12_17 and V12_19 parsers

### DIFF
--- a/src/solana/slab.ts
+++ b/src/solana/slab.ts
@@ -2655,10 +2655,6 @@ function parseConfigV12_17(data: Uint8Array, configOff: number): MarketConfig {
     fundingInvScaleNotionalE6: 0n,        // removed in v12.17
     fundingMaxPremiumBps,
     fundingMaxBpsPerSlot,
-    fundingPremiumWeightBps: 0n,
-    fundingSettlementIntervalSlots: 0n,
-    fundingPremiumDampeningE6: 0n,
-    fundingPremiumMaxBpsPerSlot: 0n,
     threshFloor: 0n,                      // removed in v12.17
     threshRiskBps: 0n,
     threshUpdateIntervalSlots: 0n,
@@ -2785,10 +2781,6 @@ function parseConfigV12_19(data: Uint8Array, configOff: number): MarketConfig {
     fundingInvScaleNotionalE6: 0n,
     fundingMaxPremiumBps,
     fundingMaxBpsPerSlot,
-    fundingPremiumWeightBps: 0n,
-    fundingSettlementIntervalSlots: 0n,
-    fundingPremiumDampeningE6: 0n,
-    fundingPremiumMaxBpsPerSlot: 0n,
     threshFloor: 0n,
     threshRiskBps: 0n,
     threshUpdateIntervalSlots: 0n,


### PR DESCRIPTION
## Summary
- Hotfix for regression from #174: parseConfigV12_17 and parseConfigV12_19 still emitted `fundingPremiumWeightBps`, `fundingSettlementIntervalSlots`, `fundingPremiumDampeningE6`, `fundingPremiumMaxBpsPerSlot` in their return objects after those fields were removed from the `MarketConfig` interface
- Results in TS2561 errors at build time: `Object literal may only specify known properties`
- tsc --noEmit passes, 732 vitest tests pass

## Test plan
- [x] `tsc --noEmit` — 0 errors
- [x] `vitest run test/` — 732 passed / 31 skipped

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>