### PR TITLE
harden: add instruction data length assertions to critical encoders (#197)

### DIFF
--- a/src/abi/instructions.ts
+++ b/src/abi/instructions.ts
@@ -624,12 +624,15 @@ export interface TradeNoCpiArgs {
 }
 
 export function encodeTradeNoCpi(args: TradeNoCpiArgs): Uint8Array {
-  return concatBytes(
+  const data = concatBytes(
     encU8(IX_TAG.TradeNoCpi),
     encU16(args.lpIdx),
     encU16(args.userIdx),
     encI128(args.size),
   );
+  // tag(1) + lpIdx(2) + userIdx(2) + size(16) = 21 bytes
+  if (data.length !== 21) throw new Error(`encodeTradeNoCpi: expected 21 bytes, got ${data.length}`);
+  return data;
 }
 
 /**
@@ -685,13 +688,16 @@ export interface TradeCpiArgs {
 }
 
 export function encodeTradeCpi(args: TradeCpiArgs): Uint8Array {
-  return concatBytes(
+  const data = concatBytes(
     encU8(IX_TAG.TradeCpi),
     encU16(args.lpIdx),
     encU16(args.userIdx),
     encI128(args.size),
     encU64(args.limitPriceE6),
   );
+  // tag(1) + lpIdx(2) + userIdx(2) + size(16) + limitPriceE6(8) = 29 bytes
+  if (data.length !== 29) throw new Error(`encodeTradeCpi: expected 29 bytes, got ${data.length}`);
+  return data;
 }
 
 /**
@@ -1213,7 +1219,10 @@ export interface ExecuteAdlArgs {
 }
 
 export function encodeExecuteAdl(args: ExecuteAdlArgs): Uint8Array {
-  return concatBytes(encU8(IX_TAG.ExecuteAdl), encU16(args.targetIdx));
+  const data = concatBytes(encU8(IX_TAG.ExecuteAdl), encU16(args.targetIdx));
+  // tag(1) + targetIdx(2) = 3 bytes
+  if (data.length !== 3) throw new Error(`encodeExecuteAdl: expected 3 bytes, got ${data.length}`);
+  return data;
 }
 
 // ============================================================================


### PR DESCRIPTION
Rebased and corrected version of #197 (from 0x-SquidSol fork).

## Summary
- Adds byte-length assertions to `encodeTradeNoCpi` (21 bytes), `encodeTradeCpi` (29 bytes), and `encodeExecuteAdl` (3 bytes)
- Corrects a bug in the original PR: `encodeTradeCpi` in main has `limitPriceE6` field (u64, added in v12.17), so correct length is 29 not 21
- Skips `encodeTradeCpiV2` (already throws via `removedInstruction()`) and `encodeUpdateConfig` (PR byte count was for an older version)

## Test plan
- [x] `pnpm build` — clean
- [x] `vitest run test/` — 732 passed / 31 skipped

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>