### PR TITLE
harden: validate all AdlApiResult top-level fields before cast (#193)

### DIFF
--- a/src/solana/adl.ts
+++ b/src/solana/adl.ts
@@ -554,6 +554,28 @@ export async function fetchAdlRankings(
     );
   }
 
-  const json = await res.json() as AdlApiResult;
-  return json;
+  const obj = await res.json() as Record<string, unknown>;
+
+  // Validate top-level fields — a schema mismatch from a compromised or
+  // updated API should throw, not silently produce undefined fields.
+  if (typeof obj.adlNeeded !== "boolean") {
+    throw new Error(`fetchAdlRankings: adlNeeded must be boolean, got ${typeof obj.adlNeeded}`);
+  }
+  if (typeof obj.capExceeded !== "boolean") {
+    throw new Error(`fetchAdlRankings: capExceeded must be boolean, got ${typeof obj.capExceeded}`);
+  }
+  if (typeof obj.slabAddress !== "string") {
+    throw new Error(`fetchAdlRankings: slabAddress must be string, got ${typeof obj.slabAddress}`);
+  }
+  if (typeof obj.pnlPosTot !== "string") {
+    throw new Error(`fetchAdlRankings: pnlPosTot must be string, got ${typeof obj.pnlPosTot}`);
+  }
+  if (typeof obj.maxPnlCap !== "string") {
+    throw new Error(`fetchAdlRankings: maxPnlCap must be string, got ${typeof obj.maxPnlCap}`);
+  }
+  if (!Array.isArray(obj.rankings)) {
+    throw new Error("fetchAdlRankings: API response missing rankings array");
+  }
+
+  return obj as unknown as AdlApiResult;
 }


### PR DESCRIPTION
Rebased version of #193 from 0x-SquidSol fork (conflict resolution applied to current main).

## Summary
- Adds 5 `typeof` guards for `adlNeeded`, `capExceeded`, `slabAddress`, `pnlPosTot`, `maxPnlCap` in `fetchAdlRankings()` before the cast
- Also adds `Array.isArray(obj.rankings)` check
- Prevents silent undefined fields when API schema changes or compromised endpoint returns malformed response

## Test plan
- [x] `pnpm build` — clean
- [x] `vitest run test/adl.test.ts` — 26 passed

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>