### PR TITLE
fix(encode): validate string format before BigInt conversion

### DIFF
--- a/src/abi/encode.ts
+++ b/src/abi/encode.ts
@@ -4,6 +4,24 @@ const U8_MAX = 0xFF;
 const U16_MAX = 0xFFFF;
 const U32_MAX = 0xFFFFFFFF;
 
+/** Decimal integer pattern: optional minus, then digits (no leading zeros except bare "0"). */
+const DECIMAL_INT_RE = /^-?(0|[1-9]\d*)$/;
+
+/**
+ * Convert a string to BigInt with format validation.
+ * Rejects whitespace, scientific notation, decimal points, hex prefixes, and
+ * other inputs that would cause BigInt() to throw an unhelpful SyntaxError.
+ */
+function safeBigInt(val: string, caller: string): bigint {
+  if (!DECIMAL_INT_RE.test(val)) {
+    throw new Error(
+      `${caller}: string must be a decimal integer (got ${JSON.stringify(val)}). ` +
+      `Example valid inputs: "0", "123", "-456"`,
+    );
+  }
+  return BigInt(val);
+}
+
 /**
  * Encode u8 (1 byte)
  */
@@ -43,7 +61,7 @@ export function encU32(val: number): Uint8Array {
  * Input: bigint or string (decimal)
  */
 export function encU64(val: bigint | string): Uint8Array {
-  const n = typeof val === "string" ? BigInt(val) : val;
+  const n = typeof val === "string" ? safeBigInt(val, "encU64") : val;
   if (n < 0n) throw new Error("encU64: value must be non-negative");
   if (n > 0xffff_ffff_ffff_ffffn) throw new Error("encU64: value exceeds u64 max");
   const buf = new Uint8Array(8);
@@ -56,7 +74,7 @@ export function encU64(val: bigint | string): Uint8Array {
  * Input: bigint or string (decimal, may be negative)
  */
 export function encI64(val: bigint | string): Uint8Array {
-  const n = typeof val === "string" ? BigInt(val) : val;
+  const n = typeof val === "string" ? safeBigInt(val, "encI64") : val;
   const min = -(1n << 63n);
   const max = (1n << 63n) - 1n;
   if (n < min || n > max) throw new Error("encI64: value out of range");
@@ -70,7 +88,7 @@ export function encI64(val: bigint | string): Uint8Array {
  * Input: bigint or string (decimal)
  */
 export function encU128(val: bigint | string): Uint8Array {
-  const n = typeof val === "string" ? BigInt(val) : val;
+  const n = typeof val === "string" ? safeBigInt(val, "encU128") : val;
   if (n < 0n) throw new Error("encU128: value must be non-negative");
   const max = (1n << 128n) - 1n;
   if (n > max) throw new Error("encU128: value exceeds u128 max");
@@ -88,7 +106,7 @@ export function encU128(val: bigint | string): Uint8Array {
  * Input: bigint or string (decimal, may be negative)
  */
 export function encI128(val: bigint | string): Uint8Array {
-  const n = typeof val === "string" ? BigInt(val) : val;
+  const n = typeof val === "string" ? safeBigInt(val, "encI128") : val;
   const min = -(1n << 127n);
   const max = (1n << 127n) - 1n;
   if (n < min || n > max) throw new Error("encI128: value out of range");


### PR DESCRIPTION
Closes #178.

Adds `safeBigInt()` helper in `src/abi/encode.ts` with a decimal-integer regex guard that rejects whitespace, scientific notation, hex prefixes, and decimal points before calling `BigInt()`. Applied to `encU64`, `encI64`, `encU128`, and `encI128`.

The original PR also patched `encodePushOraclePrice` in `instructions.ts` — that function does not exist in current main (removed in a prior sync), so that hunk is intentionally omitted.

**Test evidence:** pnpm build clean + 732/732 vitest pass.