### PR TITLE
fix(adl): pass slab data to detectSlabLayout for V2 disambiguation

### DIFF
--- a/src/solana/adl.ts
+++ b/src/solana/adl.ts
@@ -142,7 +142,7 @@ function computePnlPct(pnl: bigint, capital: bigint): bigint {
  * ```
  */
 export function isAdlTriggered(slabData: Uint8Array): boolean {
-  const layout = detectSlabLayout(slabData.length);
+  const layout = detectSlabLayout(slabData.length, slabData);
   if (!layout) return false;
   try {
     const engine = parseEngine(slabData);
@@ -191,7 +191,7 @@ export async function fetchAdlRankedPositions(
  * Useful when you already have the slab data (e.g., from a subscription).
  */
 export function rankAdlPositions(slabData: Uint8Array): AdlRankingResult {
-  const layout = detectSlabLayout(slabData.length);
+  const layout = detectSlabLayout(slabData.length, slabData);
 
   let pnlPosTot = 0n;
   try {


### PR DESCRIPTION
Closes #164.

V2 slabs have the same size as V1D; disambiguation requires reading the version field from the data buffer. Passes `slabData` as the second argument to `detectSlabLayout()` in both `isAdlTriggered()` and `rankAdlPositions()`. Without this, V2 slabs were misdetected as V1D (ENGINE_OFF 424 vs 600 = 176-byte offset error in `maxPnlCap` reads), causing missed or false ADL triggers.

**Test evidence:** pnpm build clean + 732/732 vitest pass.