### PR TITLE
fix(adl): remove Buffer.from for browser compatibility

### DIFF
--- a/src/solana/adl.ts
+++ b/src/solana/adl.ts
@@ -308,7 +308,9 @@ export function buildAdlInstruction(
       `buildAdlInstruction: targetIdx must be a non-negative integer, got ${targetIdx}`,
     );
   }
-  const data = Buffer.from(encodeExecuteAdl({ targetIdx }));
+  // TransactionInstruction accepts Uint8Array at runtime; cast avoids Buffer.from()
+  // which crashes in browser environments where Node's Buffer is undefined.
+  const data = encodeExecuteAdl({ targetIdx }) as unknown as Buffer;
 
   const keys: AccountMeta[] = [
     { pubkey: caller, isSigner: true, isWritable: false },


### PR DESCRIPTION
Closes #157.

`buildAdlInstruction()` wrapped `encodeExecuteAdl()` output in `Buffer.from()`, which throws `ReferenceError: Buffer is not defined` in browser environments. `TransactionInstruction` accepts `Uint8Array` at runtime; the fix removes the `Buffer.from()` call and uses a type cast to satisfy the TypeScript type signature without requiring Node's Buffer polyfill.

**Test evidence:** pnpm build clean + 732/732 vitest pass.