### PR TITLE
fix(slab): read V12.1 engine funding_index as i64 not i128

### DIFF
--- a/src/solana/slab.ts
+++ b/src/solana/slab.ts
@@ -3349,7 +3349,10 @@ export function parseEngine(data: Uint8Array): EngineState {
     },
     currentSlot: readU64LE(data, base + layout.engineCurrentSlotOff),
     fundingIndexQpbE6: layout.engineFundingIndexOff >= 0
-      ? readI128LE(data, base + layout.engineFundingIndexOff) : 0n,
+      ? ((layout.engineLastFundingSlotOff - layout.engineFundingIndexOff) === 8
+          ? readI64LE(data, base + layout.engineFundingIndexOff)
+          : readI128LE(data, base + layout.engineFundingIndexOff))
+      : 0n,
     lastFundingSlot: layout.engineLastFundingSlotOff >= 0
       ? readU64LE(data, base + layout.engineLastFundingSlotOff) : 0n,
     fundingRateBpsPerSlotLast,


### PR DESCRIPTION
Closes #152.

V12.1 changed `funding_index` from i128 (16 bytes) to i64 (8 bytes). `parseEngine()` unconditionally called `readI128LE`, which read 8 bytes of `funding_index` + 8 bytes of `last_funding_slot` and produced a garbage funding index value.

Fix: gap-based detection — when `(engineLastFundingSlotOff - engineFundingIndexOff) === 8`, use `readI64LE`; otherwise `readI128LE`. V12.1 gap=8 bytes (i64); all other layouts (V_ADL, V1D, V1) have gap=16 bytes (i128).

**Test evidence:** pnpm build clean + 732/732 vitest pass.