### PR TITLE
fix(validation): reject non-decimal BigInt inputs

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -121,24 +121,20 @@ export function validateIndex(value: string, field: string): number {
  * Validate a non-negative amount (u64 range).
  */
 export function validateAmount(value: string, field: string): bigint {
-  let num: bigint;
-  try {
-    num = BigInt(value);
-  } catch {
-    throw new ValidationError(
-      field,
-      `"${value}" is not a valid number. Use decimal digits only.`
-    );
-  }
+  const t = requireDecimalUIntString(value, field);
+  const num = BigInt(t);
+
   if (num < 0n) {
     throw new ValidationError(field, `must be non-negative, got ${num}`);
   }
+
   if (num > U64_MAX) {
     throw new ValidationError(
       field,
       `must be <= ${U64_MAX} (u64 max), got ${num}`
     );
   }
+
   return num;
 }
 
@@ -146,24 +142,20 @@ export function validateAmount(value: string, field: string): bigint {
  * Validate a u128 value.
  */
 export function validateU128(value: string, field: string): bigint {
-  let num: bigint;
-  try {
-    num = BigInt(value);
-  } catch {
-    throw new ValidationError(
-      field,
-      `"${value}" is not a valid number. Use decimal digits only.`
-    );
-  }
+  const t = requireDecimalUIntString(value, field);
+  const num = BigInt(t);
+
   if (num < 0n) {
     throw new ValidationError(field, `must be non-negative, got ${num}`);
   }
+
   if (num > U128_MAX) {
     throw new ValidationError(
       field,
       `must be <= ${U128_MAX} (u128 max), got ${num}`
     );
   }
+
   return num;
 }
 
@@ -172,26 +164,30 @@ export function validateU128(value: string, field: string): bigint {
  */
 export function validateI64(value: string, field: string): bigint {
   let num: bigint;
+
   try {
-    num = BigInt(value);
+    num = safeBigInt(value, field);
   } catch {
     throw new ValidationError(
       field,
       `"${value}" is not a valid number. Use decimal digits only, with optional leading minus.`
     );
   }
+
   if (num < I64_MIN) {
     throw new ValidationError(
       field,
       `must be >= ${I64_MIN} (i64 min), got ${num}`
     );
   }
+
   if (num > I64_MAX) {
     throw new ValidationError(
       field,
       `must be <= ${I64_MAX} (i64 max), got ${num}`
     );
   }
+
   return num;
 }
 
@@ -200,26 +196,30 @@ export function validateI64(value: string, field: string): bigint {
  */
 export function validateI128(value: string, field: string): bigint {
   let num: bigint;
+
   try {
-    num = BigInt(value);
+    num = safeBigInt(value, field);
   } catch {
     throw new ValidationError(
       field,
       `"${value}" is not a valid number. Use decimal digits only, with optional leading minus.`
     );
   }
+
   if (num < I128_MIN) {
     throw new ValidationError(
       field,
       `must be >= ${I128_MIN} (i128 min), got ${num}`
     );
   }
+
   if (num > I128_MAX) {
     throw new ValidationError(
       field,
       `must be <= ${I128_MAX} (i128 max), got ${num}`
     );
   }
+
   return num;
 }
 

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -93,6 +93,13 @@ console.log("Testing validation functions...\n");
   assertThrows(() => validateAmount("-100", "--amt"), "non-negative", "rejects negative");
   assertThrows(() => validateAmount("18446744073709551616", "--amt"), "u64 max", "rejects above max");
   assertThrows(() => validateAmount("abc", "--amt"), "decimal digits only", "rejects non-numeric");
+for (const bad of ["", "   ", "0x10", "0o10", "0b10", "+1", "001"]) {
+  assertThrows(
+    () => validateAmount(bad, "--amt"),
+    "valid",
+    `rejects non-decimal amount ${JSON.stringify(bad)}`
+  );
+}
 
   console.log("✓ validateAmount");
 }
@@ -105,6 +112,13 @@ console.log("Testing validation functions...\n");
 
   assertThrows(() => validateU128("-1", "--val"), "non-negative", "rejects negative");
   assertThrows(() => validateU128("340282366920938463463374607431768211456", "--val"), "u128 max", "rejects above max");
+for (const bad of ["", "   ", "0x10", "0o10", "0b10", "+1", "001"]) {
+  assertThrows(
+    () => validateU128(bad, "--val"),
+    "valid",
+    `rejects non-decimal u128 ${JSON.stringify(bad)}`
+  );
+}
 
   console.log("✓ validateU128");
 }
@@ -119,6 +133,13 @@ console.log("Testing validation functions...\n");
 
   assertThrows(() => validateI64("9223372036854775808", "--val"), "i64 max", "rejects above max");
   assertThrows(() => validateI64("-9223372036854775809", "--val"), "i64 min", "rejects below min");
+for (const bad of ["", "   ", "0x10", "0o10", "0b10", "+1", "001", "-001"]) {
+  assertThrows(
+    () => validateI64(bad, "--val"),
+    "valid",
+    `rejects non-decimal i64 ${JSON.stringify(bad)}`
+  );
+}
 
   console.log("✓ validateI64");
 }
@@ -137,6 +158,13 @@ console.log("Testing validation functions...\n");
 
   assertThrows(() => validateI128("170141183460469231731687303715884105728", "--size"), "i128 max", "rejects above max");
   assertThrows(() => validateI128("-170141183460469231731687303715884105729", "--size"), "i128 min", "rejects below min");
+for (const bad of ["", "   ", "0x10", "0o10", "0b10", "+1", "001", "-001"]) {
+  assertThrows(
+    () => validateI128(bad, "--size"),
+    "valid",
+    `rejects non-decimal i128 ${JSON.stringify(bad)}`
+  );
+}
 
   console.log("✓ validateI128");
 }


### PR DESCRIPTION
## Summary

- Replaces bare `BigInt(value)` parsing in public numeric validators with strict decimal parsing helpers.
- Adds regression coverage for non-decimal and non-canonical numeric strings.
- Fixes the regression reported in #267.

## Why

`validateAmount()`, `validateU128()`, `validateI64()`, and `validateI128()` accepted values such as hex, octal, binary, plus-prefixed, empty, whitespace-only, and leading-zero strings through JavaScript's `BigInt()` parser.

This is inconsistent with the decimal-only validation policy documented by the existing helpers.

## Validation

- `pnpm exec tsx test/validation.test.ts`
- `pnpm lint`

Closes #267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced numeric input validation to enforce stricter decimal format requirements and reject non-decimal representations (hex, octal, binary prefixes, etc.)
  * Improved error messages for validation failures to better indicate invalid input formats

* **Tests**
  * Expanded test coverage for numeric validators with additional invalid input format scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->