### PR TITLE
fix(stake): validate account discriminators in decoders

### DIFF
--- a/src/solana/stake.ts
+++ b/src/solana/stake.ts
@@ -162,6 +162,19 @@ function readU16LE(data: Uint8Array, off: number): number {
   return view.getUint16(off, /* littleEndian= */ true);
 }
 
+function requireDiscriminator(
+  accountName: string,
+  data: Uint8Array,
+  offset: number,
+  expected: Uint8Array,
+): void {
+  for (let i = 0; i < expected.length; i += 1) {
+    if (data[offset + i] !== expected[i]) {
+      throw new Error(`${accountName} invalid discriminator`);
+    }
+  }
+}
+
 // ═══════════════════════════════════════════════════════════════
 // Instruction Encoders
 // ═══════════════════════════════════════════════════════════════
@@ -404,6 +417,9 @@ export interface StakePoolState {
  * v2: 384 (stake v1 was 352; `pending_admin: [u8;32]` added at offset 288).
  */
 export const STAKE_POOL_SIZE = 384;
+export const STAKE_POOL_DISCRIMINATOR = new Uint8Array([0x53, 0x50, 0x4f, 0x4f, 0x4c, 0x5f, 0x56, 0x31]);
+export const STAKE_POOL_CURRENT_VERSION = 2;
+const STAKE_POOL_RESERVED_OFFSET = 320;
 
 /**
  * Decode a StakePool account from raw data buffer. * Uses DataView for all u64/u16 reads — browser-safe.
@@ -411,6 +427,11 @@ export const STAKE_POOL_SIZE = 384;
 export function decodeStakePool(data: Uint8Array): StakePoolState {
   if (data.length < STAKE_POOL_SIZE) {
     throw new Error(`StakePool data too short: ${data.length} < ${STAKE_POOL_SIZE}`);
+  }
+  requireDiscriminator("StakePool", data, STAKE_POOL_RESERVED_OFFSET, STAKE_POOL_DISCRIMINATOR);
+  const version = data[STAKE_POOL_RESERVED_OFFSET + 8];
+  if (version !== STAKE_POOL_CURRENT_VERSION) {
+    throw new Error(`StakePool unsupported version: ${version} !== ${STAKE_POOL_CURRENT_VERSION}`);
   }
   const bytes = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);  let off = 0;
   const isInitialized = bytes[off] === 1; off += 1;
@@ -508,6 +529,8 @@ export function decodeStakePool(data: Uint8Array): StakePoolState {
 
 /** Size of StakeDeposit on-chain (bytes). */
 export const STAKE_DEPOSIT_SIZE = 152;
+export const STAKE_DEPOSIT_DISCRIMINATOR = new Uint8Array([0x53, 0x44, 0x45, 0x50, 0x5f, 0x56, 0x31, 0x00]);
+const STAKE_DEPOSIT_RESERVED_OFFSET = 88;
 
 /** Decoded StakeDeposit PDA state. */
 export interface StakeDepositState {
@@ -536,6 +559,7 @@ export function decodeDepositPda(data: Uint8Array): StakeDepositState {
   if (data.length < STAKE_DEPOSIT_SIZE) {
     throw new Error(`StakeDeposit data too short: ${data.length} < ${STAKE_DEPOSIT_SIZE}`);
   }
+  requireDiscriminator("StakeDeposit", data, STAKE_DEPOSIT_RESERVED_OFFSET, STAKE_DEPOSIT_DISCRIMINATOR);
   return {
     isInitialized: data[0] === 1,
     bump: data[1],

--- a/test/account-decode.test.ts
+++ b/test/account-decode.test.ts
@@ -24,7 +24,6 @@ import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
-import { PublicKey } from "@solana/web3.js";
 
 import {
   parseHeader,
@@ -96,33 +95,8 @@ describe("account-decode: StakePool (devnet)", () => {
     expect(data.length).toBe(STAKE_POOL_SIZE);
   });
 
-  it("decodeStakePool returns correct fields", () => {
-    const pool = decodeStakePool(data);
-    const ex = fixture.expected_decoded;
-
-    expect(pool.isInitialized).toBe(ex["isInitialized"]);
-    expect(pool.bump).toBe(ex["bump"]);
-    expect(pool.vaultAuthorityBump).toBe(ex["vaultAuthorityBump"]);
-    expect(pool.adminTransferred).toBe(ex["adminTransferred"]);
-
-    expect(pool.slab.toBase58()).toBe(ex["slab"]);
-    expect(pool.admin.toBase58()).toBe(ex["admin"]);
-    expect(pool.collateralMint.toBase58()).toBe(ex["collateralMint"]);
-    expect(pool.lpMint.toBase58()).toBe(ex["lpMint"]);
-    expect(pool.vault.toBase58()).toBe(ex["vault"]);
-
-    expect(pool.totalDeposited).toBe(BigInt(ex["totalDeposited"] as string));
-    expect(pool.totalLpSupply).toBe(BigInt(ex["totalLpSupply"] as string));
-    expect(pool.cooldownSlots).toBe(BigInt(ex["cooldownSlots"] as string));
-    expect(pool.depositCap).toBe(BigInt(ex["depositCap"] as string));
-    expect(pool.totalFlushed).toBe(BigInt(ex["totalFlushed"] as string));
-    expect(pool.totalReturned).toBe(BigInt(ex["totalReturned"] as string));
-    expect(pool.totalWithdrawn).toBe(BigInt(ex["totalWithdrawn"] as string));
-
-    expect(pool.poolMode).toBe(ex["poolMode"]);
-    expect(pool.marketResolved).toBe(ex["marketResolved"]);
-    expect(pool.hwmEnabled).toBe(ex["hwmEnabled"]);
-    expect(pool.hwmFloorBps).toBe(ex["hwmFloorBps"]);
+  it("rejects the stale devnet fixture because it has no v2 discriminator/version", () => {
+    expect(() => decodeStakePool(data)).toThrow(/StakePool invalid discriminator/);
   });
 });
 
@@ -138,22 +112,13 @@ describe("account-decode: StakeDeposit (devnet)", () => {
     expect(data.length).toBe(STAKE_DEPOSIT_SIZE);
   });
 
-  it("decodeDepositPda returns correct fields", () => {
-    const deposit = decodeDepositPda(data);
-    const ex = fixture.expected_decoded;
-
-    expect(deposit.isInitialized).toBe(ex["isInitialized"]);
-    expect(deposit.bump).toBe(ex["bump"]);
-    expect(deposit.pool.toBase58()).toBe(ex["pool"]);
-    expect(deposit.user.toBase58()).toBe(ex["user"]);
-    expect(deposit.lastDepositSlot).toBe(BigInt(ex["lastDepositSlot"] as string));
-    expect(deposit.lpAmount).toBe(BigInt(ex["lpAmount"] as string));
+  it("rejects the stale devnet fixture because it has no discriminator", () => {
+    expect(() => decodeDepositPda(data)).toThrow(/StakeDeposit invalid discriminator/);
   });
 
-  it("deposit.pool matches stake pool account address", () => {
-    const deposit = decodeDepositPda(data);
+  it("still documents the captured pool link for fixture archaeology", () => {
     const poolFixture = loadFixture("devnet-stake-pool.json");
-    expect(deposit.pool.toBase58()).toBe(poolFixture.account_address);
+    expect(fixture.expected_decoded["pool"]).toBe(poolFixture.account_address);
   });
 });
 

--- a/test/stake.test.ts
+++ b/test/stake.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { PublicKey } from "@solana/web3.js";
 import {
-  STAKE_IX,  encodeStakeInitPool,
+  STAKE_IX,
+  encodeStakeInitPool,
   encodeStakeDeposit,
   encodeStakeWithdraw,
   encodeStakeFlushToInsurance,
@@ -21,11 +22,29 @@ import {
   encodeStakeAdminSetInsurancePolicy,
   encodeStakeSetMarketResolved,
   decodeStakePool,
+  decodeDepositPda,
   deriveStakePool,
   deriveStakeVaultAuth,
   deriveDepositPda,
   STAKE_PROGRAM_ID,
+  STAKE_POOL_DISCRIMINATOR,
+  STAKE_POOL_CURRENT_VERSION,
+  STAKE_DEPOSIT_DISCRIMINATOR,
 } from "../src/solana/stake.js";
+
+const STAKE_POOL_RESERVED_OFFSET = 320;
+const STAKE_DEPOSIT_RESERVED_OFFSET = 88;
+const TEST_POOL = new PublicKey("FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD");
+const TEST_USER = new PublicKey("GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24");
+
+function stampStakePoolIdentity(buf: Uint8Array): void {
+  buf.set(STAKE_POOL_DISCRIMINATOR, STAKE_POOL_RESERVED_OFFSET);
+  buf[STAKE_POOL_RESERVED_OFFSET + 8] = STAKE_POOL_CURRENT_VERSION;
+}
+
+function stampStakeDepositIdentity(buf: Uint8Array): void {
+  buf.set(STAKE_DEPOSIT_DISCRIMINATOR, STAKE_DEPOSIT_RESERVED_OFFSET);
+}
 
 describe("stake encoders return Uint8Array (not Buffer)", () => {
   it("encodeStakeInitPool", () => {
@@ -174,6 +193,7 @@ describe("stake encoders return Uint8Array (not Buffer)", () => {
     // pending_admin [u8;32] @ 288..320 (new in v2; zeros = no pending proposal)
     // _reserved (64 bytes) starts at 320 in v2 (was 288 in v1)
     const reservedStart = 320;
+    stampStakePoolIdentity(buf);
     buf[reservedStart + 9] = 1;   // market_resolved = true
     buf[reservedStart + 10] = 1;  // hwm_enabled = true
     dv.setUint16(reservedStart + 11, 777, true);   // hwm_floor_bps
@@ -186,6 +206,43 @@ describe("stake encoders return Uint8Array (not Buffer)", () => {
     expect(pool.epochHighWaterTvl).toBe(123n);
     expect(pool.hwmFloorBps).toBe(777);
     expect(pool.hwmLastEpoch).toBe(456n);
+  });
+
+  it("rejects stake-pool-shaped bytes with a missing discriminator", () => {
+    const buf = new Uint8Array(384);
+    expect(() => decodeStakePool(buf)).toThrow(/StakePool invalid discriminator/);
+  });
+
+  it("rejects stake pools with a stale or unsupported version byte", () => {
+    const buf = new Uint8Array(384);
+    stampStakePoolIdentity(buf);
+    buf[STAKE_POOL_RESERVED_OFFSET + 8] = STAKE_POOL_CURRENT_VERSION - 1;
+    expect(() => decodeStakePool(buf)).toThrow(/StakePool unsupported version/);
+  });
+
+  it("rejects stake-deposit-shaped bytes with a missing discriminator", () => {
+    const buf = new Uint8Array(152);
+    expect(() => decodeDepositPda(buf)).toThrow(/StakeDeposit invalid discriminator/);
+  });
+
+  it("decodes a current StakeDeposit buffer once the discriminator is present", () => {
+    const buf = new Uint8Array(152);
+    const dv = new DataView(buf.buffer);
+    buf[0] = 1;
+    buf[1] = 254;
+    buf.set(TEST_POOL.toBytes(), 8);
+    buf.set(TEST_USER.toBytes(), 40);
+    dv.setBigUint64(72, 123n, true);
+    dv.setBigUint64(80, 456n, true);
+    stampStakeDepositIdentity(buf);
+
+    const deposit = decodeDepositPda(buf);
+    expect(deposit.isInitialized).toBe(true);
+    expect(deposit.bump).toBe(254);
+    expect(deposit.pool.toBase58()).toBe(TEST_POOL.toBase58());
+    expect(deposit.user.toBase58()).toBe(TEST_USER.toBase58());
+    expect(deposit.lastDepositSlot).toBe(123n);
+    expect(deposit.lpAmount).toBe(456n);
   });
 });
 


### PR DESCRIPTION
Closes #269

## Summary

- Add SDK constants for the stake pool/deposit discriminators and current pool version.
- Make `decodeStakePool` reject missing/invalid `SPOOL_V1` and unsupported pool versions before decoding fields.
- Make `decodeDepositPda` reject missing/invalid `SDEP_V1\0` before decoding fields.
- Update tests so stale devnet stake fixtures are rejected while current-format synthetic buffers still decode.

## Proof

The on-chain stake program writes and validates:

- `SPOOL_V1` at the pool reserved region offset 320
- pool version `2` at offset 328
- `SDEP_V1\0` at the deposit reserved region offset 88

Before this PR, the SDK only checked buffer length, so `decodeStakePool(new Uint8Array(384))` and `decodeDepositPda(new Uint8Array(152))` both succeeded even though the on-chain program would reject those accounts as invalid stake state.

The new tests cover missing pool discriminator, stale/unsupported pool version, missing deposit discriminator, valid current deposit decoding, and stale fixture rejection.

## Verification

```bash
vitest run test/stake.test.ts test/account-decode.test.ts
tsc --noEmit
```