### PR TITLE
fix(stake): reject unsafe numeric encoder inputs

### DIFF
--- a/src/solana/stake.ts
+++ b/src/solana/stake.ts
@@ -167,6 +167,10 @@ function readU16LE(data: Uint8Array, off: number): number {
 // ═══════════════════════════════════════════════════════════════
 
 function u64Le(v: bigint | number): Uint8Array {
+  if (typeof v === "number" && !Number.isSafeInteger(v)) {
+    throw new Error(`u64Le: number ${v} exceeds Number.MAX_SAFE_INTEGER — use BigInt`);
+  }
+
   const big = BigInt(v);
   if (big < 0n) throw new Error(`u64Le: value must be non-negative, got ${big}`);
   if (big > 0xFFFF_FFFF_FFFF_FFFFn) throw new Error(`u64Le: value exceeds u64 max`);
@@ -175,6 +179,10 @@ function u64Le(v: bigint | number): Uint8Array {
 }
 
 function u128Le(v: bigint | number): Uint8Array {
+  if (typeof v === "number" && !Number.isSafeInteger(v)) {
+    throw new Error(`u128Le: number ${v} exceeds Number.MAX_SAFE_INTEGER — use BigInt`);
+  }
+
   const big = BigInt(v);
   if (big < 0n) throw new Error(`u128Le: value must be non-negative, got ${big}`);
   if (big > (1n << 128n) - 1n) throw new Error(`u128Le: value exceeds u128 max`);
@@ -185,7 +193,7 @@ function u128Le(v: bigint | number): Uint8Array {
 }
 
 function u16Le(v: number): Uint8Array {
-  if (v < 0 || v > 0xFFFF) throw new Error(`u16Le: value out of u16 range (0..65535), got ${v}`);  const arr = new Uint8Array(2);  new DataView(arr.buffer).setUint16(0, v, true);
+  if (!Number.isInteger(v) || v < 0 || v > 0xFFFF) throw new Error(`u16Le: value out of u16 range (0..65535), got ${v}`);  const arr = new Uint8Array(2);  new DataView(arr.buffer).setUint16(0, v, true);
   return arr;
 }
 

--- a/test/stake.test.ts
+++ b/test/stake.test.ts
@@ -67,6 +67,51 @@ describe("stake encoders return Uint8Array (not Buffer)", () => {
     expect(data[10]).toBe(0);
   });
 
+  it("rejects unsafe JavaScript number inputs in stake amount encoders", () => {
+    const unsafe = Number.MAX_SAFE_INTEGER + 1;
+
+    expect(() => encodeStakeInitPool(unsafe, 1n)).toThrow(
+      /Number\.MAX_SAFE_INTEGER|safe/i,
+    );
+    expect(() => encodeStakeInitPool(1n, unsafe)).toThrow(
+      /Number\.MAX_SAFE_INTEGER|safe/i,
+    );
+
+    expect(() => encodeStakeDeposit(unsafe)).toThrow(
+      /Number\.MAX_SAFE_INTEGER|safe/i,
+    );
+
+    expect(() => encodeStakeWithdraw(unsafe)).toThrow(
+      /Number\.MAX_SAFE_INTEGER|safe/i,
+    );
+
+    expect(() => encodeStakeFlushToInsurance(unsafe)).toThrow(
+      /Number\.MAX_SAFE_INTEGER|safe/i,
+    );
+
+    expect(() => encodeStakeUpdateConfig(unsafe, undefined)).toThrow(
+      /Number\.MAX_SAFE_INTEGER|safe/i,
+    );
+    expect(() => encodeStakeUpdateConfig(undefined, unsafe)).toThrow(
+      /Number\.MAX_SAFE_INTEGER|safe/i,
+    );
+  });
+
+  it("still accepts safe number and bigint stake amounts", () => {
+    expect(encodeStakeDeposit(Number.MAX_SAFE_INTEGER)).toBeInstanceOf(
+      Uint8Array,
+    );
+    expect(encodeStakeWithdraw(Number.MAX_SAFE_INTEGER)).toBeInstanceOf(
+      Uint8Array,
+    );
+    expect(encodeStakeDeposit(9_007_199_254_740_993n)).toBeInstanceOf(
+      Uint8Array,
+    );
+    expect(encodeStakeWithdraw(9_007_199_254_740_993n)).toBeInstanceOf(
+      Uint8Array,
+    );
+  });
+
   it("encodeStakeTransferAdmin", () => {
     expect(() => encodeStakeTransferAdmin()).toThrow(/tag 5/i);
   });


### PR DESCRIPTION
## Summary

- Rejects unsafe JavaScript `number` inputs before stake amount encoding.
- Preserves support for safe integer `number` inputs and `bigint` inputs.
- Adds regression tests for unsafe number rejection in stake instruction encoders.

## Why

Stake amount encoders accepted unsafe JavaScript numbers and converted them with `BigInt(v)`.

Since unsafe numbers may already be rounded by JavaScript before conversion, the SDK could serialize an amount different from the caller's intended value.

## Changes

- Adds `Number.isSafeInteger()` checks to `u64Le()` and `u128Le()` for `number` inputs.
- Adds integer validation to `u16Le()`.
- Adds stake encoder regression tests for unsafe numeric inputs.
- Adds positive coverage for safe `number` and large `bigint` inputs.

## Validation

- `pnpm exec vitest run test/stake.test.ts --reporter=verbose`
- `pnpm lint`

Closes #272