### PR TITLE
fix(math): validate fee split bps totals

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7364,6 +7364,13 @@ function computeFeeSplit(totalFee, config) {
   if (config.lpBps === 0n && config.protocolBps === 0n && config.creatorBps === 0n) {
     return [totalFee, 0n, 0n];
   }
+  const totalBps = config.lpBps + config.protocolBps + config.creatorBps;
+  if (config.lpBps < 0n || config.protocolBps < 0n || config.creatorBps < 0n) {
+    throw new Error("computeFeeSplit: bps values must be non-negative");
+  }
+  if (totalBps !== 10000n) {
+    throw new Error(`computeFeeSplit: bps values must sum to 10000, got ${totalBps}`);
+  }
   const lp = totalFee * config.lpBps / 10000n;
   const protocol = totalFee * config.protocolBps / 10000n;
   const creator = totalFee - lp - protocol;

--- a/src/math/trading.ts
+++ b/src/math/trading.ts
@@ -174,6 +174,14 @@ export function computeFeeSplit(
   if (config.lpBps === 0n && config.protocolBps === 0n && config.creatorBps === 0n) {
     return [totalFee, 0n, 0n];
   }
+  const totalBps = config.lpBps + config.protocolBps + config.creatorBps;
+  if (config.lpBps < 0n || config.protocolBps < 0n || config.creatorBps < 0n) {
+    throw new Error("computeFeeSplit: bps values must be non-negative");
+  }
+  if (totalBps !== 10000n) {
+    throw new Error(`computeFeeSplit: bps values must sum to 10000, got ${totalBps}`);
+  }
+
   const lp = (totalFee * config.lpBps) / 10000n;
   const protocol = (totalFee * config.protocolBps) / 10000n;
   const creator = totalFee - lp - protocol;

--- a/test/dynamic-fees.test.ts
+++ b/test/dynamic-fees.test.ts
@@ -38,6 +38,17 @@ function assertEq(actual: bigint | number, expected: bigint | number, msg: strin
   }
 }
 
+function assertThrows(fn: () => unknown, msg: string): void {
+  try {
+    fn();
+    console.error(`  ✗ ${msg}: expected throw`);
+    failed++;
+  } catch {
+    console.log(`  ✓ ${msg}`);
+    passed++;
+  }
+}
+
 // =============================================================================
 // computeDynamicFeeBps
 // =============================================================================
@@ -344,6 +355,22 @@ console.log("\n--- computeFeeSplit ---");
   assertEq(lp, 5000n, "all-zero config: 100% to LP");
   assertEq(protocol, 0n, "all-zero config: 0 to protocol");
   assertEq(creator, 0n, "all-zero config: 0 to creator");
+}
+
+// Invalid non-legacy bps totals are rejected instead of minting negative creator shares.
+{
+  assertThrows(
+    () => computeFeeSplit(10000n, { lpBps: 9000n, protocolBps: 2000n, creatorBps: 0n }),
+    "over-100% bps split is rejected",
+  );
+  assertThrows(
+    () => computeFeeSplit(10000n, { lpBps: 7000n, protocolBps: 2000n, creatorBps: 0n }),
+    "under-100% non-legacy bps split is rejected",
+  );
+  assertThrows(
+    () => computeFeeSplit(10000n, { lpBps: -1n, protocolBps: 0n, creatorBps: 10001n }),
+    "negative bps split is rejected",
+  );
 }
 
 // Zero fee amount


### PR DESCRIPTION
## Summary

- reject non-legacy fee split configs whose bps are negative or do not sum to exactly 10000
- preserve the all-zero legacy LP fallback
- add regression coverage for over-allocated, under-allocated, and negative bps splits

Fixes #278

## Tests

```bash
PATH=/Users/rehannek/Documents/percolator/percolator-keeper/node_modules/.bin:$PATH tsx test/dynamic-fees.test.ts
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for fee split configurations to ensure all inputs meet required specifications and prevent invalid configurations from being processed.

* **Tests**
  * Added test coverage for fee split configuration validation, including scenarios with invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->