### PR TITLE
fix(encode): require decimal integer strings

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3,6 +3,14 @@ import { PublicKey } from "@solana/web3.js";
 var U8_MAX = 255;
 var U16_MAX = 65535;
 var U32_MAX = 4294967295;
+var DECIMAL_INT_RE = /^-?(0|[1-9]\d*)$/;
+function parseDecimalBigInt(val, fnName) {
+  if (typeof val !== "string") return val;
+  if (!DECIMAL_INT_RE.test(val)) {
+    throw new Error(`${fnName}: value must be a decimal integer string`);
+  }
+  return BigInt(val);
+}
 function encU8(val) {
   if (!Number.isInteger(val) || val < 0 || val > U8_MAX) {
     throw new Error(`encU8: value out of range (0..255), got ${val}`);
@@ -26,7 +34,7 @@ function encU32(val) {
   return buf;
 }
 function encU64(val) {
-  const n = typeof val === "string" ? BigInt(val) : val;
+  const n = parseDecimalBigInt(val, "encU64");
   if (n < 0n) throw new Error("encU64: value must be non-negative");
   if (n > 0xffffffffffffffffn) throw new Error("encU64: value exceeds u64 max");
   const buf = new Uint8Array(8);
@@ -34,7 +42,7 @@ function encU64(val) {
   return buf;
 }
 function encI64(val) {
-  const n = typeof val === "string" ? BigInt(val) : val;
+  const n = parseDecimalBigInt(val, "encI64");
   const min = -(1n << 63n);
   const max = (1n << 63n) - 1n;
   if (n < min || n > max) throw new Error("encI64: value out of range");
@@ -43,7 +51,7 @@ function encI64(val) {
   return buf;
 }
 function encU128(val) {
-  const n = typeof val === "string" ? BigInt(val) : val;
+  const n = parseDecimalBigInt(val, "encU128");
   if (n < 0n) throw new Error("encU128: value must be non-negative");
   const max = (1n << 128n) - 1n;
   if (n > max) throw new Error("encU128: value exceeds u128 max");
@@ -56,7 +64,7 @@ function encU128(val) {
   return buf;
 }
 function encI128(val) {
-  const n = typeof val === "string" ? BigInt(val) : val;
+  const n = parseDecimalBigInt(val, "encI128");
   const min = -(1n << 127n);
   const max = (1n << 127n) - 1n;
   if (n < min || n > max) throw new Error("encI128: value out of range");

--- a/src/abi/encode.ts
+++ b/src/abi/encode.ts
@@ -3,6 +3,15 @@ import { PublicKey } from "@solana/web3.js";
 const U8_MAX = 0xFF;
 const U16_MAX = 0xFFFF;
 const U32_MAX = 0xFFFFFFFF;
+const DECIMAL_INT_RE = /^-?(0|[1-9]\d*)$/;
+
+function parseDecimalBigInt(val: bigint | string, fnName: string): bigint {
+  if (typeof val !== "string") return val;
+  if (!DECIMAL_INT_RE.test(val)) {
+    throw new Error(`${fnName}: value must be a decimal integer string`);
+  }
+  return BigInt(val);
+}
 
 /**
  * Encode u8 (1 byte)
@@ -43,7 +52,7 @@ export function encU32(val: number): Uint8Array {
  * Input: bigint or string (decimal)
  */
 export function encU64(val: bigint | string): Uint8Array {
-  const n = typeof val === "string" ? BigInt(val) : val;
+  const n = parseDecimalBigInt(val, "encU64");
   if (n < 0n) throw new Error("encU64: value must be non-negative");
   if (n > 0xffff_ffff_ffff_ffffn) throw new Error("encU64: value exceeds u64 max");
   const buf = new Uint8Array(8);
@@ -56,7 +65,7 @@ export function encU64(val: bigint | string): Uint8Array {
  * Input: bigint or string (decimal, may be negative)
  */
 export function encI64(val: bigint | string): Uint8Array {
-  const n = typeof val === "string" ? BigInt(val) : val;
+  const n = parseDecimalBigInt(val, "encI64");
   const min = -(1n << 63n);
   const max = (1n << 63n) - 1n;
   if (n < min || n > max) throw new Error("encI64: value out of range");
@@ -70,7 +79,7 @@ export function encI64(val: bigint | string): Uint8Array {
  * Input: bigint or string (decimal)
  */
 export function encU128(val: bigint | string): Uint8Array {
-  const n = typeof val === "string" ? BigInt(val) : val;
+  const n = parseDecimalBigInt(val, "encU128");
   if (n < 0n) throw new Error("encU128: value must be non-negative");
   const max = (1n << 128n) - 1n;
   if (n > max) throw new Error("encU128: value exceeds u128 max");
@@ -88,7 +97,7 @@ export function encU128(val: bigint | string): Uint8Array {
  * Input: bigint or string (decimal, may be negative)
  */
 export function encI128(val: bigint | string): Uint8Array {
-  const n = typeof val === "string" ? BigInt(val) : val;
+  const n = parseDecimalBigInt(val, "encI128");
   const min = -(1n << 127n);
   const max = (1n << 127n) - 1n;
   if (n < min || n > max) throw new Error("encI128: value out of range");

--- a/test/abi.test.ts
+++ b/test/abi.test.ts
@@ -72,6 +72,16 @@ function assertBuf(actual: Uint8Array, expected: number[], msg: string): void {
   }
 }
 
+function assertThrows(fn: () => unknown, msg: string): void {
+  let threw = false;
+  try {
+    fn();
+  } catch {
+    threw = true;
+  }
+  assert(threw, `${msg} must throw`);
+}
+
 function decI128Le(data: Uint8Array, offset: number): bigint {
   let value = 0n;
   for (let i = 0; i < 16; i++) value |= BigInt(data[offset + i]) << BigInt(i * 8);
@@ -208,6 +218,16 @@ console.log("Testing encode functions...\n");
     "encI128(-1000000)"
   );
   console.log("✓ encI128");
+}
+
+// Decimal string inputs must be canonical decimal integers.
+{
+  assertThrows(() => encU64("0x10"), 'encU64("0x10")');
+  assertThrows(() => encU64(" 10"), 'encU64(" 10")');
+  assertThrows(() => encI64("+10"), 'encI64("+10")');
+  assertThrows(() => encU128("01"), 'encU128("01")');
+  assertThrows(() => encI128("1e3"), 'encI128("1e3")');
+  console.log("✓ integer encoders reject non-decimal string forms");
 }
 
 // Test encPubkey


### PR DESCRIPTION
## Summary

- add a shared canonical decimal string parser for ABI integer encoders
- reject hex, plus-prefixed, whitespace, leading-zero, and exponent string forms before `BigInt()` conversion
- add ABI regression assertions for the rejected string forms

Fixes #280

## Tests

```bash
pnpm exec tsx test/abi.test.ts
```
