### PR TITLE
fix: add stake admin rotation encoders

### DIFF
--- a/src/solana/__tests__/stake-cpi.test.ts
+++ b/src/solana/__tests__/stake-cpi.test.ts
@@ -29,6 +29,8 @@ import {
   encodeStakeWithdraw,
   encodeStakeFlushToInsurance,
   encodeStakeUpdateConfig,
+  encodeStakeProposeAdmin,
+  encodeStakeAcceptAdmin,
   encodeStakeTransferAdmin,
   encodeStakeAdminSetOracleAuthority,
   encodeStakeAdminSetRiskThreshold,
@@ -323,7 +325,21 @@ describe('Stake CPI Integration — Full Lifecycle', () => {
   });
 
   describe('Phase 5: Admin CPI Forwarding', () => {
-    it('AdminSetOracleAuthority rejects removed stake tag 6', () => {
+    it('ProposeAdmin encodes live stake tag 5', () => {
+      const newAdmin = Keypair.generate().publicKey;
+      const data = encodeStakeProposeAdmin(newAdmin);
+      expect(data[0]).toBe(STAKE_IX.ProposeAdmin);
+      expect(data.length).toBe(33);
+      expect(new PublicKey(data.subarray(1)).equals(newAdmin)).toBe(true);
+    });
+
+    it('AcceptAdmin encodes live stake tag 6', () => {
+      const data = encodeStakeAcceptAdmin();
+      expect(data[0]).toBe(STAKE_IX.AcceptAdmin);
+      expect(data.length).toBe(1);
+    });
+
+    it('AdminSetOracleAuthority rejects legacy stake tag 6 name', () => {
       const newAuth = Keypair.generate().publicKey;
       expect(() => encodeStakeAdminSetOracleAuthority(newAuth)).toThrow(/tag 6/i);
     });
@@ -360,7 +376,7 @@ describe('Stake CPI Integration — Full Lifecycle', () => {
       expect(() => encodeStakeAdminSetInsurancePolicy(authority, 100_000n, 500, 100n)).toThrow(/tag 11/i);
     });
 
-    it('TransferAdmin rejects removed stake tag 5', () => {
+    it('TransferAdmin rejects legacy stake tag 5 name', () => {
       expect(() => encodeStakeTransferAdmin()).toThrow(/tag 5/i);
     });
 
@@ -452,7 +468,7 @@ describe('Stake PDA Chain — Multi-Market Isolation', () => {
 describe('Stake Instruction Tags — No Gaps or Conflicts', () => {
   it('tags match the live on-chain mapping, including tombstones and aliases', () => {
     const tags = Object.values(STAKE_IX);
-    expect(tags).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 11, 12, 13, 14, 15, 16, 18]);
+    expect(tags).toEqual([0, 1, 2, 3, 4, 5, 6, 5, 6, 7, 8, 9, 10, 10, 11, 12, 13, 14, 15, 16, 18]);
   });
 
   it('live encoders produce the correct tag byte and tombstoned encoders throw', () => {
@@ -462,6 +478,8 @@ describe('Stake Instruction Tags — No Gaps or Conflicts', () => {
       [STAKE_IX.Withdraw, encodeStakeWithdraw(0n)],
       [STAKE_IX.FlushToInsurance, encodeStakeFlushToInsurance(0n)],
       [STAKE_IX.UpdateConfig, encodeStakeUpdateConfig()],
+      [STAKE_IX.ProposeAdmin, encodeStakeProposeAdmin(PublicKey.default)],
+      [STAKE_IX.AcceptAdmin, encodeStakeAcceptAdmin()],
       [STAKE_IX.ReturnInsurance, encodeStakeReturnInsurance(0n)],
       [STAKE_IX.AdminWithdrawInsurance, encodeStakeAdminWithdrawInsurance(0n)],
       [STAKE_IX.AccrueFees, encodeStakeAccrueFees()],

--- a/src/solana/__tests__/stake.test.ts
+++ b/src/solana/__tests__/stake.test.ts
@@ -12,6 +12,8 @@ import {
   encodeStakeWithdraw,
   encodeStakeFlushToInsurance,
   encodeStakeUpdateConfig,
+  encodeStakeProposeAdmin,
+  encodeStakeAcceptAdmin,
   encodeStakeTransferAdmin,
   encodeStakeAdminSetOracleAuthority,
   encodeStakeAdminSetRiskThreshold,
@@ -54,6 +56,8 @@ describe('STAKE_IX tags', () => {
     expect(STAKE_IX.Withdraw).toBe(2);
     expect(STAKE_IX.FlushToInsurance).toBe(3);
     expect(STAKE_IX.UpdateConfig).toBe(4);
+    expect(STAKE_IX.ProposeAdmin).toBe(5);
+    expect(STAKE_IX.AcceptAdmin).toBe(6);
     expect(STAKE_IX.TransferAdmin).toBe(5);
     expect(STAKE_IX.AdminSetOracleAuthority).toBe(6);
     expect(STAKE_IX.AdminSetRiskThreshold).toBe(7);
@@ -166,11 +170,25 @@ describe('Instruction encoders', () => {
     expect(readU64LE(buf, 11)).toBe(500n);
   });
 
-  it('encodeStakeTransferAdmin rejects removed tag 5', () => {
+  it('encodeStakeProposeAdmin — tag 5 + new admin', () => {
+    const newAdmin = Keypair.generate().publicKey;
+    const buf = encodeStakeProposeAdmin(newAdmin);
+    expect(buf[0]).toBe(5);
+    expect(buf.length).toBe(33);
+    expect(new PublicKey(buf.subarray(1, 33)).equals(newAdmin)).toBe(true);
+  });
+
+  it('encodeStakeAcceptAdmin — tag 6', () => {
+    const buf = encodeStakeAcceptAdmin();
+    expect(buf[0]).toBe(6);
+    expect(buf.length).toBe(1);
+  });
+
+  it('encodeStakeTransferAdmin rejects legacy tag 5 name', () => {
     expect(() => encodeStakeTransferAdmin()).toThrow(/tag 5/i);
   });
 
-  it('encodeStakeAdminSetOracleAuthority rejects removed tag 6', () => {
+  it('encodeStakeAdminSetOracleAuthority rejects legacy tag 6 name', () => {
     const auth = Keypair.generate().publicKey;
     expect(() => encodeStakeAdminSetOracleAuthority(auth)).toThrow(/tag 6/i);
   });

--- a/src/solana/stake.ts
+++ b/src/solana/stake.ts
@@ -92,9 +92,13 @@ export const STAKE_IX = {
   Withdraw: 2,
   FlushToInsurance: 3,
   UpdateConfig: 4,
-  /** @deprecated Removed on-chain in stake v3. This tag now rejects. */
+  /** Step 1 of two-step stake admin rotation. */
+  ProposeAdmin: 5,
+  /** Step 2 of two-step stake admin rotation. */
+  AcceptAdmin: 6,
+  /** @deprecated Legacy one-step admin transfer name. Use ProposeAdmin. */
   TransferAdmin: 5,
-  /** @deprecated Removed on-chain in stake v3. This tag now rejects. */
+  /** @deprecated Legacy admin CPI proxy name. Tag 6 is now AcceptAdmin. */
   AdminSetOracleAuthority: 6,
   /** @deprecated Removed on-chain in stake v3. This tag now rejects. */
   AdminSetRiskThreshold: 7,
@@ -250,16 +254,29 @@ export function encodeStakeUpdateConfig(
 
 function removedStakeInstruction(name: string, tag: number): never {
   throw new Error(
-    `${name} (stake tag ${tag}) was removed on-chain in percolator-stake v3 and must not be sent.`,
+    `${name} (legacy stake tag ${tag}) no longer matches the live on-chain instruction and must not be sent.`,
   );
 }
 
-/** @deprecated Removed on-chain in stake v3. Throws instead of emitting a dead instruction. */
+/** Tag 5: ProposeAdmin — current admin proposes a pending admin. */
+export function encodeStakeProposeAdmin(newAdmin: PublicKey): Uint8Array {
+  return concatBytes(
+    new Uint8Array([STAKE_IX.ProposeAdmin]),
+    newAdmin.toBytes(),
+  );
+}
+
+/** Tag 6: AcceptAdmin — pending admin accepts ownership. */
+export function encodeStakeAcceptAdmin(): Uint8Array {
+  return new Uint8Array([STAKE_IX.AcceptAdmin]);
+}
+
+/** @deprecated Legacy one-step admin transfer name. Use encodeStakeProposeAdmin instead. */
 export function encodeStakeTransferAdmin(): Uint8Array {
   return removedStakeInstruction('encodeStakeTransferAdmin', STAKE_IX.TransferAdmin);
 }
 
-/** @deprecated Removed on-chain in stake v3. Throws instead of emitting a dead instruction. */
+/** @deprecated Removed admin CPI proxy. Tag 6 is now encodeStakeAcceptAdmin. */
 export function encodeStakeAdminSetOracleAuthority(newAuthority: PublicKey): Uint8Array {
   void newAuthority;
   return removedStakeInstruction('encodeStakeAdminSetOracleAuthority', STAKE_IX.AdminSetOracleAuthority);


### PR DESCRIPTION
## Summary

Fixes dcccrypto/percolator-sdk#297.

The stake SDK treated tags `5` and `6` as removed legacy admin instructions even though the current stake program uses them for live two-step admin rotation:

- tag `5`: `ProposeAdmin { new_admin }`
- tag `6`: `AcceptAdmin`

This PR adds the current encoders while keeping the old legacy function names as throwing tombstones so old callers do not silently get new semantics.

## Changes

- Add `STAKE_IX.ProposeAdmin = 5` and `STAKE_IX.AcceptAdmin = 6`.
- Add `encodeStakeProposeAdmin(newAdmin)` -> `[5] + new_admin[32]`.
- Add `encodeStakeAcceptAdmin()` -> `[6]`.
- Keep `encodeStakeTransferAdmin()` and `encodeStakeAdminSetOracleAuthority()` as deprecated throwing legacy names.
- Update stake SDK tests to cover the live wire formats and the legacy tombstones.

## Tests

```bash
pnpm exec vitest run src/solana/__tests__/stake.test.ts src/solana/__tests__/stake-cpi.test.ts
pnpm run lint
pnpm test
```
