### PR TITLE
fix(test): resolve abi.test.ts conflict left by #302/#304

### DIFF
--- a/test/abi.test.ts
+++ b/test/abi.test.ts
@@ -83,13 +83,10 @@ function assertThrows(fn: () => unknown, msg: string): void {
   assert(threw, `${msg} must throw`);
 }
 
-<<<<<<< HEAD
 /**
  * Assert that a synchronous function throws and that the thrown error message
  * matches the expected pattern.
  */
-=======
->>>>>>> origin/main
 function assertThrowsMatch(fn: () => unknown, pattern: RegExp, msg: string): void {
   try {
     fn();


### PR DESCRIPTION
#302 and #304 both appended an `assertThrowsMatch` helper to `test/abi.test.ts`; #304's squash-merge left conflict markers on main, breaking `pnpm test`. Resolved to a single definition (doc comment kept); full suite green (836 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)