### PR TITLE
fix(sdk): PumpSwap spot price must apply token decimals (#323)

### DIFF
--- a/src/solana/dex-oracle.ts
+++ b/src/solana/dex-oracle.ts
@@ -80,7 +80,15 @@ export function computeDexSpotPriceE6(
   switch (dexType) {
     case "pumpswap":
       if (!vaultData) throw new Error("PumpSwap requires vaultData (base and quote vault accounts)");
-      return computePumpSwapPriceE6(data, vaultData);
+      // #323: PumpSwap vaults hold raw atomic balances; the ratio is atomic-per-atomic,
+      // not a human price. The caller MUST supply mint decimals so the result matches the
+      // e6-human-price contract that Meteora (#226) and Raydium (#210) already honour.
+      // Without this, any token/WSOL pool (6-dec base, 9-dec quote) is off by 10^3 →
+      // wrongful liquidations and free profit on the other side.
+      if (!decimals) {
+        throw new Error("PumpSwap requires decimals { base, quote } (mint decimals)");
+      }
+      return computePumpSwapPriceE6(data, vaultData, decimals.base, decimals.quote);
     case "raydium-clmm":
       return computeRaydiumClmmPriceE6(data);
     case "meteora-dlmm":
@@ -121,12 +129,21 @@ function parsePumpSwapPool(poolAddress: PublicKey, data: Uint8Array): DexPoolInf
 const SPL_TOKEN_AMOUNT_MIN_LEN = 72;
 
 /**
- * Compute PumpSwap price: quote_amount * 1e6 / base_amount.
+ * Compute PumpSwap price: (quoteAmount / baseAmount) scaled to e6, with decimal adjustment.
+ *
+ * #323: vault amounts are in atomic units (lamports/raw tokens). Dividing atomics directly
+ * gives an atomic-per-atomic ratio, not a human price. Multiply by 10^(decBase − decQuote)
+ * to convert — the same correction applied by Meteora (#226) and Raydium (#210). Truncation
+ * is deferred to a single division at the end (BigInt is arbitrary-precision) so micro-prices
+ * are not silently zeroed before the decimal scale is applied.
+ *
  * @internal
  */
 function computePumpSwapPriceE6(
   _poolData: Uint8Array,
   vaultData: { base: Uint8Array; quote: Uint8Array },
+  decimalsBase: number,
+  decimalsQuote: number,
 ): bigint {
   if (vaultData.base.length < SPL_TOKEN_AMOUNT_MIN_LEN) {
     throw new Error(`PumpSwap base vault data too short: ${vaultData.base.length} < ${SPL_TOKEN_AMOUNT_MIN_LEN}`);
@@ -134,6 +151,8 @@ function computePumpSwapPriceE6(
   if (vaultData.quote.length < SPL_TOKEN_AMOUNT_MIN_LEN) {
     throw new Error(`PumpSwap quote vault data too short: ${vaultData.quote.length} < ${SPL_TOKEN_AMOUNT_MIN_LEN}`);
   }
+  assertTokenDecimals("PumpSwap", "base", decimalsBase);
+  assertTokenDecimals("PumpSwap", "quote", decimalsQuote);
 
   const baseDv = new DataView(vaultData.base.buffer, vaultData.base.byteOffset, vaultData.base.byteLength);
   const quoteDv = new DataView(vaultData.quote.buffer, vaultData.quote.byteOffset, vaultData.quote.byteLength);
@@ -142,7 +161,15 @@ function computePumpSwapPriceE6(
   const quoteAmount = readU64LE(quoteDv, 64);
 
   if (baseAmount === 0n) return 0n;
-  return (quoteAmount * 1_000_000n) / baseAmount;
+
+  // diff > 0: base has more decimals than quote → multiply (price in quote terms is larger).
+  // diff < 0: quote has more decimals than base → divide (price in quote terms is smaller).
+  // Defer truncation: scale the numerator before dividing to avoid zeroing micro-prices.
+  const diff = decimalsBase - decimalsQuote;
+  if (diff >= 0) {
+    return (quoteAmount * 1_000_000n * 10n ** BigInt(diff)) / baseAmount;
+  }
+  return (quoteAmount * 1_000_000n) / (baseAmount * 10n ** BigInt(-diff));
 }
 
 // ============================================================================

--- a/test/dex-oracle.test.ts
+++ b/test/dex-oracle.test.ts
@@ -110,12 +110,12 @@ assertThrows(
   "pumpswap parse too short"
 );
 
-// Price computation — normal
+// Price computation — symmetric decimals (6/6): no decimal correction needed
 {
   const poolData = makePumpSwapPoolData();
   const base = makeSplTokenAccount(1_000_000_000n); // 1B base
   const quote = makeSplTokenAccount(500_000_000n);   // 500M quote
-  const price = computeDexSpotPriceE6("pumpswap", poolData, { base, quote });
+  const price = computeDexSpotPriceE6("pumpswap", poolData, { base, quote }, { base: 6, quote: 6 });
   // price = 500M * 1e6 / 1B = 500_000
   assert(price === 500_000n, `pumpswap normal price: expected 500000, got ${price}`);
 }
@@ -125,16 +125,16 @@ assertThrows(
   const poolData = makePumpSwapPoolData();
   const base = makeSplTokenAccount(0n);
   const quote = makeSplTokenAccount(100n);
-  const price = computeDexSpotPriceE6("pumpswap", poolData, { base, quote });
+  const price = computeDexSpotPriceE6("pumpswap", poolData, { base, quote }, { base: 6, quote: 6 });
   assert(price === 0n, "pumpswap zero base returns 0");
 }
 
-// Price — very large amounts
+// Price — very large amounts (symmetric decimals → no adjustment)
 {
   const poolData = makePumpSwapPoolData();
   const base = makeSplTokenAccount(18_446_744_073_709_551_615n); // u64 max
   const quote = makeSplTokenAccount(18_446_744_073_709_551_615n);
-  const price = computeDexSpotPriceE6("pumpswap", poolData, { base, quote });
+  const price = computeDexSpotPriceE6("pumpswap", poolData, { base, quote }, { base: 6, quote: 6 });
   assert(price === 1_000_000n, `pumpswap equal large amounts: expected 1000000, got ${price}`);
 }
 
@@ -143,7 +143,7 @@ assertThrows(
   () => computeDexSpotPriceE6("pumpswap", makePumpSwapPoolData(), {
     base: new Uint8Array(10),
     quote: makeSplTokenAccount(100n),
-  }),
+  }, { base: 6, quote: 6 }),
   "too short",
   "pumpswap base vault too short"
 );
@@ -153,6 +153,85 @@ assertThrows(
   () => computeDexSpotPriceE6("pumpswap", makePumpSwapPoolData()),
   "vaultData",
   "pumpswap missing vaultData"
+);
+
+// Missing decimals
+assertThrows(
+  () => computeDexSpotPriceE6("pumpswap", makePumpSwapPoolData(), {
+    base: makeSplTokenAccount(1_000n),
+    quote: makeSplTokenAccount(500n),
+  }),
+  "requires decimals",
+  "pumpswap missing decimals"
+);
+
+// #323: token-decimal adjustment — canonical PumpSwap case: pump token (6 dec) / WSOL (9 dec).
+// True price: 50 WSOL / 1,000,000 tokens = 0.00005 WSOL/token → human e6 = 50.
+// Atomic: baseAmount = 1e12, quoteAmount = 5e10.
+// Bug (before fix): 5e10 * 1e6 / 1e12 = 50_000 (off by 10^(9-6) = 1000×).
+// Fix: diff = decBase - decQuote = 6 - 9 = -3 → divide by 10^3 → 50.
+{
+  const DEC_BASE = 6;  // pump token
+  const DEC_QUOTE = 9; // WSOL
+  const baseAmount  = 1_000_000n * 10n ** BigInt(DEC_BASE);  // 1e12 atomic
+  const quoteAmount =        50n * 10n ** BigInt(DEC_QUOTE); // 5e10 atomic
+
+  const poolData = makePumpSwapPoolData();
+  const vaultData = {
+    base:  makeSplTokenAccount(baseAmount),
+    quote: makeSplTokenAccount(quoteAmount),
+  };
+
+  const got = computeDexSpotPriceE6("pumpswap", poolData, vaultData, { base: DEC_BASE, quote: DEC_QUOTE });
+  const correctE6 = 50n;      // 0.00005 WSOL/token × 1e6
+  const buggyE6   = 50_000n;  // pre-fix: atomic ratio × 1e6, decimals dropped (1000× too large)
+
+  assert(got === correctE6, `#323 pump/WSOL (6/9): expected ${correctE6}, got ${got} (was ${buggyE6} before fix)`);
+  assert(got !== buggyE6, `#323 pump/WSOL result must not be the pre-fix 1000× value`);
+}
+
+// #323: symmetric case (6/6) must still be correct — no over/under correction.
+{
+  const baseAmount  = 1_000_000n * 10n ** 6n; // 1e12
+  const quoteAmount =        50n * 10n ** 6n; // 5e7
+  const vaultData = {
+    base:  makeSplTokenAccount(baseAmount),
+    quote: makeSplTokenAccount(quoteAmount),
+  };
+  const got = computeDexSpotPriceE6("pumpswap", makePumpSwapPoolData(), vaultData, { base: 6, quote: 6 });
+  assert(got === 50n, `#323 pump/USDC (6/6): expected 50, got ${got}`);
+}
+
+// #323: base > quote decimals (e.g. 9-dec base / 6-dec quote) → scale UP.
+// Atomic price = 5e10 / 1e12 = 0.05. diff = 9-6 = +3 → human price = 0.05 * 10^3 = 50.
+{
+  const baseAmount  = 1_000_000n * 10n ** 9n; // 1e15 atomic (1M tokens of 9-dec base)
+  const quoteAmount =        50n * 10n ** 6n; // 5e7 atomic (50 tokens of 6-dec quote)
+  const vaultData = {
+    base:  makeSplTokenAccount(baseAmount),
+    quote: makeSplTokenAccount(quoteAmount),
+  };
+  const got = computeDexSpotPriceE6("pumpswap", makePumpSwapPoolData(), vaultData, { base: 9, quote: 6 });
+  // human price = 50/1_000_000 = 0.00005 → e6 = 50
+  assert(got === 50n, `#323 9-dec base / 6-dec quote: expected 50, got ${got}`);
+}
+
+// #323: decimals out of range are rejected.
+assertThrows(
+  () => computeDexSpotPriceE6("pumpswap", makePumpSwapPoolData(), {
+    base:  makeSplTokenAccount(1_000n),
+    quote: makeSplTokenAccount(500n),
+  }, { base: 99, quote: 6 }),
+  "out of range",
+  "pumpswap decimals base out of range"
+);
+assertThrows(
+  () => computeDexSpotPriceE6("pumpswap", makePumpSwapPoolData(), {
+    base:  makeSplTokenAccount(1_000n),
+    quote: makeSplTokenAccount(500n),
+  }, { base: 6, quote: 99 }),
+  "out of range",
+  "pumpswap decimals quote out of range"
 );
 
 console.log("  ✓ PumpSwap");


### PR DESCRIPTION
Verified [SECURITY][CRITICAL] finding. The PumpSwap price path returned raw atomic ratio `quoteAmount·1e6/baseAmount` with NO decimal normalization, while the Meteora (#226) and Raydium (#210) paths were already fixed. For the canonical pump.fun pool (6-dec base / 9-dec WSOL quote) the mark price was wrong by **10^(9−6) = 1000×** — verified: a 1M-token / 50-WSOL pool returned 50,000 instead of 50. A wrong mark feeds liquidations/margin, hence fund-critical.

Fix: mirror the Meteora/Raydium idiom — `diff = decimalsBase − decimalsQuote`; `diff≥0` → `quoteAmount·1e6·10^diff / baseAmount`; `diff<0` → `quoteAmount·1e6 / (baseAmount·10^-diff)` (deferred truncation; `assertTokenDecimals` bounds). Verified the scaling against both reference paths by hand. 847 tests pass (5 new PumpSwap-decimals cases), tsc + build clean.

NOTE: this makes the PumpSwap call-site of `computeDexSpotPriceE6` require `decimals` (a breaking signature change) — internal call sites updated; external consumers pick it up on the next SDK version bump (SDK does not auto-publish, gated on the v17 cutover).

Closes #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)