### PR TITLE
chore(sdk): wire live v17 devnet program IDs + flip V17_PROGRAMS_DEPLOYED

### DIFF
--- a/src/config/program-ids.ts
+++ b/src/config/program-ids.ts
@@ -44,25 +44,27 @@ Object.freeze(PROGRAM_IDS.mainnet);
 Object.freeze(PROGRAM_IDS);
 
 /**
- * v17 program IDs — placeholder until the v17 converged program is deployed.
+ * v17 program IDs — live devnet addresses deployed 2026-06-24.
  *
- * The v17 program uses `declare_id!("Perco1ator111111111111111111111111111111111")`
- * in its source. This will be replaced with the real on-chain address when deployed.
- *
- * v17 converged programs are NOT deployed (cutover is Phase 7 gate).
+ * Devnet addresses are canonical. Mainnet addresses are pending the mainnet
+ * cutover (Phase 7 gate) — mainnet fields will be filled then.
  */
 export const PROGRAM_IDS_V17 = {
-  /** v17 wrapper placeholder (declare_id! value from v16_program.rs). */
-  percolator: "Perco1ator111111111111111111111111111111111",
-  /** v17 stake placeholder. */
-  stake: "Per5taTe111111111111111111111111111111111111",
+  /** v17 wrapper (percolator) — devnet live. */
+  percolator: "69VUZ7a2BeXBTpRRManLamF5UWTaNR9B1hy5Se3cdXy9",
+  /** v17 stake/vault — devnet live. */
+  stake: "51CeUNpbXovK2BRADPyssuf3Q1xWGabEK9pYkp5mqVhQ",
+  /** v17 matcher — devnet live. */
+  matcher: "4seJWjv3R5qfXY8R5ntuPHWsoqcVvaxvfFSnU2AnGMhT",
+  /** v17 NFT — devnet live. */
+  nft: "5TnritLtHS76s5iV8axqDmqhcmJKMRUekMGrk9rBTqSP",
 } as const;
 Object.freeze(PROGRAM_IDS_V17);
 
-/** True only after canonical v17 wrapper IDs have replaced the placeholders above. */
-export const V17_PROGRAMS_DEPLOYED = false;
+/** True after canonical v17 addresses replaced placeholders (devnet deployed 2026-06-24). */
+export const V17_PROGRAMS_DEPLOYED = true;
 
-/** The v17 wrapper placeholder PublicKey. Use only before mainnet cutover. */
+/** The v17 wrapper PublicKey. */
 export const PROGRAM_ID_V17 = new PublicKey(PROGRAM_IDS_V17.percolator);
 
 export type Network = "devnet" | "mainnet";
@@ -72,12 +74,15 @@ const KNOWN_PROGRAM_IDS = new Set<string>([
   PROGRAM_IDS.devnet.percolator,
   PROGRAM_IDS.mainnet.percolator,
   PROGRAM_IDS_V17.percolator,
+  PROGRAM_IDS_V17.stake,
+  PROGRAM_IDS_V17.nft,
 ]);
 
 /** Allowlist of legitimate matcher program addresses (all networks). */
 const KNOWN_MATCHER_IDS = new Set<string>([
   PROGRAM_IDS.devnet.matcher,
   PROGRAM_IDS.mainnet.matcher,
+  PROGRAM_IDS_V17.matcher,
 ]);
 
 /**
@@ -123,14 +128,24 @@ export function getProgramId(network?: Network): PublicKey {
   // Use provided network or detect from env — default to devnet (never mainnet silently)
   const detectedNetwork = getCurrentNetwork();
   const targetNetwork = network ?? detectedNetwork;
-  if (!V17_PROGRAMS_DEPLOYED) {
+
+  if (V17_PROGRAMS_DEPLOYED) {
+    if (targetNetwork === "devnet") {
+      return new PublicKey(PROGRAM_IDS_V17.percolator);
+    }
+    // Mainnet cutover not yet done — fail closed to prevent sending v17 instructions
+    // to the legacy mainnet program.
     throw new Error(
-      `Percolator v17 program is not deployed for ${targetNetwork}; refusing to return a legacy program ID for v17 SDK encoders. Set PROGRAM_ID to an explicitly trusted v17 deployment to override ambient resolution.`,
+      `Percolator v17 program is not deployed on mainnet yet; cutover is pending. ` +
+      `Set PROGRAM_ID to an explicitly trusted mainnet v17 deployment to override.`,
     );
   }
-  const programId = PROGRAM_IDS[targetNetwork].percolator;
 
-  return new PublicKey(programId);
+  // V17_PROGRAMS_DEPLOYED === false (should not be reachable given the flag is true above,
+  // but kept as a safety net for future flag resets during testing).
+  throw new Error(
+    `Percolator v17 program is not deployed for ${targetNetwork}; refusing to return a legacy program ID for v17 SDK encoders. Set PROGRAM_ID to an explicitly trusted v17 deployment to override ambient resolution.`,
+  );
 }
 
 /**
@@ -157,18 +172,22 @@ export function getMatcherProgramId(network?: Network): PublicKey {
   // Use provided network or detect from env — default to devnet (never mainnet silently)
   const detectedNetwork = getCurrentNetwork();
   const targetNetwork = network ?? detectedNetwork;
-  if (!V17_PROGRAMS_DEPLOYED) {
+
+  if (V17_PROGRAMS_DEPLOYED) {
+    if (targetNetwork === "devnet") {
+      return new PublicKey(PROGRAM_IDS_V17.matcher);
+    }
+    // Mainnet cutover not yet done.
     throw new Error(
-      `Percolator v17 matcher program is not deployed for ${targetNetwork}; refusing to return a legacy matcher program ID for v17 SDK encoders. Set MATCHER_PROGRAM_ID to an explicitly trusted v17 deployment to override ambient resolution.`,
+      `Percolator v17 matcher program is not deployed on mainnet yet; cutover is pending. ` +
+      `Set MATCHER_PROGRAM_ID to an explicitly trusted mainnet v17 deployment to override.`,
     );
   }
-  const programId = PROGRAM_IDS[targetNetwork].matcher;
 
-  if (!programId) {
-    throw new Error(`Matcher program not deployed on ${targetNetwork}`);
-  }
-
-  return new PublicKey(programId);
+  // V17_PROGRAMS_DEPLOYED === false safety net.
+  throw new Error(
+    `Percolator v17 matcher program is not deployed for ${targetNetwork}; refusing to return a legacy matcher program ID for v17 SDK encoders. Set MATCHER_PROGRAM_ID to an explicitly trusted v17 deployment to override ambient resolution.`,
+  );
 }
 
 /**

--- a/test/program-ids.test.ts
+++ b/test/program-ids.test.ts
@@ -5,7 +5,13 @@ import {
   getProgramId,
   getMatcherProgramId,
   getCurrentNetwork,
+  PROGRAM_IDS_V17,
 } from "../src/config/program-ids.js";
+
+const V17_PERCOLATOR = "69VUZ7a2BeXBTpRRManLamF5UWTaNR9B1hy5Se3cdXy9";
+const V17_MATCHER = "4seJWjv3R5qfXY8R5ntuPHWsoqcVvaxvfFSnU2AnGMhT";
+const V17_STAKE = "51CeUNpbXovK2BRADPyssuf3Q1xWGabEK9pYkp5mqVhQ";
+const V17_NFT = "5TnritLtHS76s5iV8axqDmqhcmJKMRUekMGrk9rBTqSP";
 
 describe("safeEnv", () => {
   it("reads an existing env var", () => {
@@ -19,22 +25,51 @@ describe("safeEnv", () => {
   });
 });
 
+describe("PROGRAM_IDS_V17 shape", () => {
+  it("exposes all four v17 addresses", () => {
+    expect(PROGRAM_IDS_V17.percolator).toBe(V17_PERCOLATOR);
+    expect(PROGRAM_IDS_V17.matcher).toBe(V17_MATCHER);
+    expect(PROGRAM_IDS_V17.stake).toBe(V17_STAKE);
+    expect(PROGRAM_IDS_V17.nft).toBe(V17_NFT);
+  });
+});
+
 describe("getProgramId", () => {
-  it("fails closed for devnet while v17 program ids are placeholders", () => {
-    expect(() => getProgramId("devnet")).toThrow(/v17 program is not deployed/i);
+  it("returns the v17 devnet percolator address for devnet", () => {
+    const pk = getProgramId("devnet");
+    expect(pk).toBeInstanceOf(PublicKey);
+    expect(pk.toBase58()).toBe(V17_PERCOLATOR);
   });
 
-  it("fails closed for mainnet while v17 program ids are placeholders", () => {
-    expect(() => getProgramId("mainnet")).toThrow(/v17 program is not deployed/i);
+  it("still fails closed for mainnet (mainnet cutover not done)", () => {
+    expect(() => getProgramId("mainnet")).toThrow(/not deployed on mainnet yet/i);
   });
 
-  it("defaults to devnet but refuses to return a legacy program id", () => {
+  it("defaults to devnet (no NETWORK set) and returns v17 devnet address", () => {
     const saved = process.env.NETWORK;
     delete process.env.NETWORK;
     try {
-      expect(() => getProgramId()).toThrow(/devnet/);
+      const pk = getProgramId();
+      expect(pk.toBase58()).toBe(V17_PERCOLATOR);
     } finally {
       if (saved !== undefined) process.env.NETWORK = saved;
+    }
+  });
+
+  it("allows a v17 percolator address as PROGRAM_ID env override WITHOUT the opt-in (now in allowlist)", () => {
+    const saved = process.env.PROGRAM_ID;
+    const savedOptIn = process.env.PERCOLATOR_SDK_ALLOW_PROGRAM_OVERRIDE;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.PROGRAM_ID = V17_PERCOLATOR;
+    delete process.env.PERCOLATOR_SDK_ALLOW_PROGRAM_OVERRIDE;
+    try {
+      const pk = getProgramId();
+      expect(pk.toBase58()).toBe(V17_PERCOLATOR);
+    } finally {
+      warn.mockRestore();
+      if (saved === undefined) delete process.env.PROGRAM_ID;
+      else process.env.PROGRAM_ID = saved;
+      if (savedOptIn !== undefined) process.env.PERCOLATOR_SDK_ALLOW_PROGRAM_OVERRIDE = savedOptIn;
     }
   });
 
@@ -74,12 +109,42 @@ describe("getProgramId", () => {
 });
 
 describe("getMatcherProgramId", () => {
-  it("fails closed for devnet while v17 matcher program ids are placeholders", () => {
-    expect(() => getMatcherProgramId("devnet")).toThrow(/v17 matcher program is not deployed/i);
+  it("returns the v17 devnet matcher address for devnet", () => {
+    const pk = getMatcherProgramId("devnet");
+    expect(pk).toBeInstanceOf(PublicKey);
+    expect(pk.toBase58()).toBe(V17_MATCHER);
   });
 
-  it("fails closed for mainnet while v17 matcher program ids are placeholders", () => {
-    expect(() => getMatcherProgramId("mainnet")).toThrow(/v17 matcher program is not deployed/i);
+  it("still fails closed for mainnet (mainnet cutover not done)", () => {
+    expect(() => getMatcherProgramId("mainnet")).toThrow(/not deployed on mainnet yet/i);
+  });
+
+  it("defaults to devnet (no NETWORK set) and returns v17 devnet matcher address", () => {
+    const saved = process.env.NETWORK;
+    delete process.env.NETWORK;
+    try {
+      const pk = getMatcherProgramId();
+      expect(pk.toBase58()).toBe(V17_MATCHER);
+    } finally {
+      if (saved !== undefined) process.env.NETWORK = saved;
+    }
+  });
+
+  it("allows a v17 matcher address as MATCHER_PROGRAM_ID env override WITHOUT the opt-in (now in allowlist)", () => {
+    const saved = process.env.MATCHER_PROGRAM_ID;
+    const savedOptIn = process.env.PERCOLATOR_SDK_ALLOW_PROGRAM_OVERRIDE;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.MATCHER_PROGRAM_ID = V17_MATCHER;
+    delete process.env.PERCOLATOR_SDK_ALLOW_PROGRAM_OVERRIDE;
+    try {
+      const pk = getMatcherProgramId();
+      expect(pk.toBase58()).toBe(V17_MATCHER);
+    } finally {
+      warn.mockRestore();
+      if (saved === undefined) delete process.env.MATCHER_PROGRAM_ID;
+      else process.env.MATCHER_PROGRAM_ID = saved;
+      if (savedOptIn !== undefined) process.env.PERCOLATOR_SDK_ALLOW_PROGRAM_OVERRIDE = savedOptIn;
+    }
   });
 
   it("allows an explicit MATCHER_PROGRAM_ID override for trusted v17 deployments (with opt-in)", () => {


### PR DESCRIPTION
v17 programs are deployed to devnet. PROGRAM_IDS_V17 now carries the live addresses (wrapper 69VUZ7a2…, matcher 4seJWjv3R5…, nft 5TnritLtHS76…, stake 51CeUNpb…); V17_PROGRAMS_DEPLOYED=true. getProgramId/getMatcherProgramId('devnet') return the v17 addresses (mainnet still throws until its cutover); all four added to the KNOWN allowlists so env overrides work without the opt-in. 851 tests pass. Git only — no npm publish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated v17 program routing to use the deployed devnet addresses for supported program IDs and matcher IDs.
  * Expanded allowed program lists to recognize additional v17 addresses.

* **Bug Fixes**
  * Improved environment-based resolution so v17 devnet program IDs are returned by default.
  * Mainnet now fails closed with a clear error until cutover is available.
  * Existing approved overrides for v17 addresses now work without extra opt-in flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->