### PR TITLE
fix: clamp computePnlPercent and computeFundingRateAnnualized instead of throwing

### DIFF
--- a/src/math/trading.ts
+++ b/src/math/trading.ts
@@ -202,11 +202,12 @@ export function computePnlPercent(
 ): number {
   if (capital === 0n) return 0;
   const scaledPct = (pnlTokens * 10_000n) / capital;
-  if (scaledPct > BigInt(Number.MAX_SAFE_INTEGER) || scaledPct < BigInt(-Number.MAX_SAFE_INTEGER)) {
-    throw new Error(
-      `computePnlPercent: scaled result ${scaledPct} exceeds Number.MAX_SAFE_INTEGER — precision loss`,
-    );
-  }
+  // Clamp rather than throw: values outside MAX_SAFE_INTEGER represent effectively
+  // infinite gain/loss for display purposes; returning a clamped sentinel prevents
+  // unhandled exceptions from crashing the UI on large positions.
+  const MAX_DISPLAY = BigInt(Number.MAX_SAFE_INTEGER);
+  if (scaledPct > MAX_DISPLAY) return Number.MAX_SAFE_INTEGER / 100;
+  if (scaledPct < -MAX_DISPLAY) return -(Number.MAX_SAFE_INTEGER / 100);
   return Number(scaledPct) / 100;
 }
 
@@ -237,11 +238,10 @@ const MIN_SAFE_BIGINT = BigInt(-Number.MAX_SAFE_INTEGER);
 export function computeFundingRateAnnualized(
   fundingRateBpsPerSlot: bigint,
 ): number {
-  if (fundingRateBpsPerSlot > MAX_SAFE_BIGINT || fundingRateBpsPerSlot < MIN_SAFE_BIGINT) {
-    throw new Error(
-      `computeFundingRateAnnualized: value ${fundingRateBpsPerSlot} exceeds safe integer range`,
-    );
-  }
+  // Clamp rather than throw: extreme funding rates are display-only values;
+  // returning +/-Infinity is correct JS behaviour and prevents uncaught exceptions.
+  if (fundingRateBpsPerSlot > MAX_SAFE_BIGINT) return Infinity;
+  if (fundingRateBpsPerSlot < MIN_SAFE_BIGINT) return -Infinity;
   const bpsPerSlot = Number(fundingRateBpsPerSlot);
   const slotsPerYear = 2.5 * 60 * 60 * 24 * 365; // ~400ms slots
   return (bpsPerSlot * slotsPerYear) / 100;

--- a/test/trading.test.ts
+++ b/test/trading.test.ts
@@ -121,13 +121,18 @@ assert(computePnlPercent(10000n, 10000n) === 100, "100% profit");
   assert(result === 5, "large values → 5% (no truncation)");
 }
 {
-  // Extreme PnL that would exceed MAX_SAFE_INTEGER after scaling
-  try {
-    computePnlPercent(1n << 100n, 1n);
-    assert(false, "should have thrown for extreme PnL");
-  } catch (e: any) {
-    assert(e.message.includes("MAX_SAFE_INTEGER"), "throws precision-loss error for extreme PnL");
-  }
+  // Extreme PnL that would exceed MAX_SAFE_INTEGER after scaling now CLAMPS to a
+  // display sentinel instead of throwing — a display-only value must never crash
+  // the UI on a very large position (see computePnlPercent).
+  const MAX_DISPLAY_PCT = Number.MAX_SAFE_INTEGER / 100;
+  assert(
+    computePnlPercent(1n << 100n, 1n) === MAX_DISPLAY_PCT,
+    "extreme positive PnL clamps to +MAX_SAFE_INTEGER/100",
+  );
+  assert(
+    computePnlPercent(-(1n << 100n), 1n) === -MAX_DISPLAY_PCT,
+    "extreme negative PnL clamps to -MAX_SAFE_INTEGER/100",
+  );
 }
 
 // --- computeEstimatedEntryPrice ---


### PR DESCRIPTION
Fixes #327

## Changes

- `src/math/trading.ts`
  - `computePnlPercent`: replace `throw` with a clamped return (`Number.MAX_SAFE_INTEGER / 100`) when `scaledPct` exceeds the safe integer range
  - `computeFundingRateAnnualized`: replace `throw` with `return Infinity` / `return -Infinity` for the same boundary condition

## Why clamp instead of throw

Both functions are called from UI render paths with no try/catch. Returning a sentinel value (a very large percentage or Infinity) is correct behaviour for "effectively infinite" results and does not crash the page. The original throw was added to surface precision concerns but broke the caller contract for a pure display utility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extreme profit and loss percentages are now capped at the maximum displayable value instead of causing errors.
  * Extreme annualized funding rates now return positive or negative infinity rather than failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->